### PR TITLE
Change license from ISC to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 qmu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ if (isOk(result)) {
 
 ## License
 
-ISC License - see LICENSE file for details.
+MIT License - see LICENSE file for details.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/qmu/plgg.git"
   },
   "author": "qmu",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/qmu/plgg/issues"
   },


### PR DESCRIPTION
## Summary
• Update package.json license field from ISC to MIT
• Add standard MIT LICENSE file with copyright notice
• Update README.md license reference to reflect MIT license

## Test plan
- [x] Verify package.json license field is updated
- [x] Confirm MIT LICENSE file is properly formatted
- [x] Check README.md license reference is updated

🤖 Generated with [Claude Code](https://claude.ai/code)