### PR TITLE
CI: build plgg-test in the deploy-guide dependency loop

### DIFF
--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -40,10 +40,13 @@ jobs:
       # cross-package types resolve through the `file:` dist symlinks, so every
       # package must be built first, in dependency order (same order as
       # workloads/development/Dockerfile, extended to the full family).
+      # plgg-test is included so `npm install` provides the @types/node +
+      # typescript its source (e.g. src/Resolve/hook.ts) needs when TypeDoc
+      # generates its API reference; it depends only on plgg, so it follows it.
       - name: Build package dists (dependency order)
         run: |
           set -e
-          for pkg in plgg plgg-http plgg-router plgg-view plgg-kit \
+          for pkg in plgg plgg-test plgg-http plgg-router plgg-view plgg-kit \
                      plgg-server plgg-fetch plgg-sql plgg-foundry; do
             echo "::group::build $pkg"
             (cd "packages/$pkg" && npm install && npm run build)


### PR DESCRIPTION
## Problem

The `Deploy Guide` run for the #44 merge **failed** at the *Build the guide* step: `gen-api.mjs` runs TypeDoc over `plgg-test/src`, but the deploy-guide build loop omitted `plgg-test`, so its deps (`@types/node`, `typescript`) were never `npm install`ed. TypeDoc hit 56 errors in `plgg-test/src/Resolve/hook.ts` (`Cannot find name 'node:path'`, `Cannot find module 'typescript'`, …).

## Fix

Add `plgg-test` to the dependency-order build loop in `deploy-guide.yml`, right after `plgg` (its only dependency). `gen-api.mjs` generates an API reference for all 10 packages including plgg-test; the loop now matches that set.

This is the build-order fragility called out in the #44 branch story §6, manifesting as a hard failure. It passed locally only because plgg-test's `node_modules` were already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)