### PR TITLE
Add the plggmatic UI design framework to the monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ its name); this section is the top-level index that links down to each.
 
 - **[`packages/guide/`](packages/guide/)** - The official plgg family guide: a plggpress-built static documentation site (private `@plgg/guide`, not published)
 - **[`packages/example/`](packages/example/)** - Example usage project: the SSR + CSR round-trip over one Elm-Architecture program
+- **[`packages/plggmatic/`](packages/plggmatic/)** - Column-oriented UI design framework on the plgg family: a typed light/dark color scheme, `row`/`column`/`pane` layout combinators, and fundamental components as pure `(props) => Html<Msg>`
+- **[`packages/site/`](packages/site/)** - The plggpress-built documentation site for plggmatic (private `@plggmatic/site`, not published)
+- **[`packages/plggmatic-example/`](packages/plggmatic-example/)** - The plggmatic workbench: a traversable column-stack (Miller columns) demo app served under the docs at `/example/`
 
 ## Installation
 

--- a/packages/example/package-lock.json
+++ b/packages/example/package-lock.json
@@ -60,7 +60,7 @@
       }
     },
     "../plgg-server": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",
@@ -75,7 +75,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-auth/package-lock.json
+++ b/packages/plgg-auth/package-lock.json
@@ -51,7 +51,7 @@
       }
     },
     "../plgg-db-migration": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",
@@ -71,7 +71,7 @@
       }
     },
     "../plgg-http": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg"
@@ -84,7 +84,7 @@
       }
     },
     "../plgg-server": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",
@@ -112,7 +112,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-bundle/package-lock.json
+++ b/packages/plgg-bundle/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-cli/package-lock.json
+++ b/packages/plgg-cli/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-db-migration/package-lock.json
+++ b/packages/plgg-db-migration/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plgg-db-migration",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plgg-db-migration",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",
@@ -64,7 +64,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-fetch/package-lock.json
+++ b/packages/plgg-fetch/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "../plgg-http": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg"
@@ -58,7 +58,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-foundry/package-lock.json
+++ b/packages/plgg-foundry/package-lock.json
@@ -58,7 +58,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-highlight/package-lock.json
+++ b/packages/plgg-highlight/package-lock.json
@@ -63,7 +63,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-http/package-lock.json
+++ b/packages/plgg-http/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plgg-http",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plgg-http",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg"
@@ -44,7 +44,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-kit/package-lock.json
+++ b/packages/plgg-kit/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-md/package-lock.json
+++ b/packages/plgg-md/package-lock.json
@@ -45,7 +45,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-router/package-lock.json
+++ b/packages/plgg-router/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-server/package-lock.json
+++ b/packages/plgg-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plgg-server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plgg-server",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",
@@ -46,7 +46,7 @@
       }
     },
     "../plgg-http": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg"
@@ -59,7 +59,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-sql/package-lock.json
+++ b/packages/plgg-sql/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-test/package-lock.json
+++ b/packages/plgg-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plgg-test",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plgg-test",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",

--- a/packages/plgg-view/package-lock.json
+++ b/packages/plgg-view/package-lock.json
@@ -44,7 +44,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plgg-view/src/Program/usecase/render.ts
+++ b/packages/plgg-view/src/Program/usecase/render.ts
@@ -463,6 +463,31 @@ export const waapiPlay: Play = (node, motion) =>
     : Promise.resolve();
 
 /**
+ * SVG needs its namespace: an `<svg>`/`<path>` created via plain
+ * `createElement` is an inert `HTMLUnknownElement` that never draws. These are
+ * the two SVG tags the typed builders vocabulary ships (`svg` holds `path`
+ * children only); extend alongside the builders if that vocabulary grows.
+ */
+const SVG_TAGS: ReadonlyArray<SoftStr> = [
+  "svg",
+  "path",
+];
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/**
+ * Creates the right kind of element for a tag: namespaced for the SVG
+ * vocabulary, plain HTML otherwise. Both return `Element`, which is all the
+ * attribute/keyed/motion seams require.
+ */
+const createElementFor = (
+  tag: SoftStr,
+): Element =>
+  SVG_TAGS.some((t) => t === tag)
+    ? document.createElementNS(SVG_NS, tag)
+    : document.createElement(tag);
+
+/**
  * Builds a fresh DOM node from an {@link Html} tree — text becomes a `Text`
  * node, an element a created node with safe attributes, wired handlers, and
  * appended children. Used on first paint and whenever a node must be replaced.
@@ -479,7 +504,7 @@ export const createNode =
       [
         element$(),
         ({ content }): Node => {
-          const el = document.createElement(
+          const el = createElementFor(
             content.tag,
           );
           content.attributes.forEach(

--- a/packages/plgg/package-lock.json
+++ b/packages/plgg/package-lock.json
@@ -31,7 +31,7 @@
       }
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/plggmatic-example/.gitignore
+++ b/packages/plggmatic-example/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/plggmatic-example/.prettierrc.json
+++ b/packages/plggmatic-example/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 50,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSameLine": false
+}

--- a/packages/plggmatic-example/README.md
+++ b/packages/plggmatic-example/README.md
@@ -1,0 +1,12 @@
+# @plggmatic/example
+
+> **UNSTABLE** - Experimental study work. Part of the [plgg monorepo](../../README.md).
+
+The **workbench** — an independent client-side app demonstrating
+[plggmatic](../plggmatic/)'s column-oriented layout as a **traversable column
+stack** (Miller columns): drilling into a section pushes a column, drilling into
+a note pushes another, and the whole stack is serialized into the URL so a deep
+link reproduces the arrangement and the browser back button reverses each push.
+[plgg-view](../plgg-view/)'s `application` runtime owns the history/link wiring;
+the app stays pure. Built by the in-house app bundler into a self-contained
+`dist/`, served under the docs site at `/example/`.

--- a/packages/plggmatic-example/bundle.config.ts
+++ b/packages/plggmatic-example/bundle.config.ts
@@ -1,0 +1,23 @@
+// In-house bundler config for the example client app.
+// target:"app" → a single self-contained ESM bundle
+// (dist/main.js, what index.html loads), with plggmatic
+// and the plgg family INLINED from their built dists — a
+// browser cannot resolve a bare `import "plggmatic"`, so
+// the leaf app is where bundling deps is correct (the
+// mirror of the libraries' externalize decision). The
+// build script copies index.html beside it, making
+// `dist/` the self-contained deployable the docs site
+// nests under `/example/`.
+export default {
+  target: "app",
+  root: import.meta.dirname,
+  rootDir: "src",
+  outDir: "dist",
+  entries: [{ name: "main", input: "main.ts" }],
+  formats: ["es"],
+  fileNamePattern: "[name].js",
+  alias: {
+    prefix: "@plggmatic/example",
+    srcRoot: "src",
+  },
+};

--- a/packages/plggmatic-example/index.html
+++ b/packages/plggmatic-example/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1"
+    />
+    <title>
+      Field Notes — a plggmatic workbench
+    </title>
+  </head>
+  <body>
+    <!-- CSR entry. The build copies this file into
+         dist/ beside the bundled ./main.js, so dist/ is
+         a self-contained static app the docs site can
+         nest under /example/. -->
+    <div id="root"></div>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/packages/plggmatic-example/package-lock.json
+++ b/packages/plggmatic-example/package-lock.json
@@ -1,0 +1,205 @@
+{
+  "name": "@plggmatic/example",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@plggmatic/example",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "plgg-view": "file:../plgg-view",
+        "plggmatic": "file:../plggmatic"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plgg": {
+      "version": "0.0.27",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plgg-bundle": {
+      "version": "0.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-bundle": "bin/plgg-bundle.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-test": "file:../plgg-test"
+      }
+    },
+    "../../../plgg/packages/plgg-test": {
+      "version": "0.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-test": "bin/plgg-test.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle"
+      },
+      "engines": {
+        "node": ">=22.6"
+      }
+    },
+    "../../../plgg/packages/plgg-view": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plgg": {
+      "version": "0.0.27",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plgg-bundle": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-bundle": "bin/plgg-bundle.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-test": "file:../plgg-test"
+      }
+    },
+    "../plgg-test": {
+      "version": "0.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-test": "bin/plgg-test.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle"
+      },
+      "engines": {
+        "node": ">=22.6"
+      }
+    },
+    "../plgg-view": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plggmatic": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "plgg-view": "file:../plgg-view"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/plgg": {
+      "resolved": "../plgg",
+      "link": true
+    },
+    "node_modules/plgg-bundle": {
+      "resolved": "../plgg-bundle",
+      "link": true
+    },
+    "node_modules/plgg-test": {
+      "resolved": "../plgg-test",
+      "link": true
+    },
+    "node_modules/plgg-view": {
+      "resolved": "../plgg-view",
+      "link": true
+    },
+    "node_modules/plggmatic": {
+      "resolved": "../plggmatic",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/plggmatic-example/package.json
+++ b/packages/plggmatic-example/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@plggmatic/example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "The reference plggmatic app — an independent client-side program (plgg-view Elm Architecture) displaying a workbench variation of the column-oriented layout: a drawer nav column, a fixed list column, and a fluid reading column, with URL-reflected selection and a live scheme toggle.",
+  "scripts": {
+    "build": "plgg-bundle && node src/stamp.ts",
+    "test": "tsc --noEmit && plgg-test src",
+    "tsc": "tsc --noEmit",
+    "tsc:watch": "tsc --noEmit --watch",
+    "test:watch": "plgg-test src --watch",
+    "coverage": "tsc --noEmit && plgg-test src --coverage",
+    "coverage:watch": "plgg-test src --coverage --watch",
+    "preview": "python3 -m http.server --directory dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qmu/plggmatic.git"
+  },
+  "author": "qmu",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/qmu/plggmatic/issues"
+  },
+  "homepage": "https://github.com/qmu/plggmatic#readme",
+  "dependencies": {
+    "plgg": "file:../plgg",
+    "plgg-view": "file:../plgg-view",
+    "plggmatic": "file:../plggmatic"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "plgg-bundle": "file:../plgg-bundle",
+    "plgg-test": "file:../plgg-test",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/plggmatic-example/src/app.spec.ts
+++ b/packages/plggmatic-example/src/app.spec.ts
@@ -1,0 +1,273 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import { some, none, getOr } from "plgg";
+import { makeUrl } from "plgg-view/client";
+import { renderToString } from "plgg-view";
+import {
+  type Model,
+  init,
+  update,
+  view,
+  toUrl,
+  parseUrl,
+  noteHref,
+  schemeClassCss,
+} from "./app.ts";
+
+const root: Model = init(makeUrl("/", ""));
+
+const count = (
+  hay: string,
+  needle: string,
+): number => hay.split(needle).length - 1;
+
+test("init at the root has an empty stack", () =>
+  all([
+    check(getOr("-")(root.section), toBe("-")),
+    check(getOr("-")(root.note), toBe("-")),
+    check(root.scheme, toBe("light")),
+  ]));
+
+test("url depth round-trips through parse and toUrl", () => {
+  const model: Model = {
+    base: "/",
+    section: some("geology"),
+    note: some("strata"),
+    scheme: "light",
+  };
+  const url = toUrl(model);
+  const parsed = parseUrl(url);
+  return all([
+    check(
+      url.search,
+      toBe("?s=geology&n=strata"),
+    ),
+    check(
+      getOr("-")(parsed.section),
+      toBe("geology"),
+    ),
+    check(
+      getOr("-")(parsed.note),
+      toBe("strata"),
+    ),
+    // canonical: same model, same string
+    check(toUrl(model).search, toBe(url.search)),
+    // root depth serializes to an empty search
+    check(toUrl(root).search, toBe("")),
+  ]);
+});
+
+test("a nested mount keeps its base in links and toUrl", () => {
+  const nested = init(
+    makeUrl("/example/", "?s=geology"),
+  );
+  const projected = toUrl({
+    ...nested,
+    note: some("strata"),
+  });
+  return all([
+    check(nested.base, toBe("/example/")),
+    check(projected.path, toBe("/example/")),
+    check(
+      renderToString(view(nested)).includes(
+        'href="/example/?s=geology"',
+      ),
+      toBe(true),
+    ),
+  ]);
+});
+
+test("unknown ids truncate the stack instead of erroring", () => {
+  const badSection = parseUrl(
+    makeUrl("/", "?s=nope&n=ghost"),
+  );
+  const badNote = parseUrl(
+    makeUrl("/", "?s=botany&n=ghost"),
+  );
+  return all([
+    check(
+      getOr("-")(badSection.section),
+      toBe("-"),
+    ),
+    check(getOr("-")(badSection.note), toBe("-")),
+    check(
+      getOr("-")(badNote.section),
+      toBe("botany"),
+    ),
+    check(getOr("-")(badNote.note), toBe("-")),
+  ]);
+});
+
+test("update folds url changes and scheme toggles", () => {
+  const navigated = update(
+    {
+      kind: "urlChanged",
+      url: makeUrl("/", "?s=weather&n=fog"),
+    },
+    root,
+  );
+  const toggled = update(
+    { kind: "toggleScheme" },
+    navigated,
+  );
+  return all([
+    check(
+      getOr("-")(navigated.section),
+      toBe("weather"),
+    ),
+    check(
+      getOr("-")(navigated.note),
+      toBe("fog"),
+    ),
+    check(toggled.scheme, toBe("dark")),
+    // navigation state untouched by the toggle
+    check(
+      getOr("-")(toggled.section),
+      toBe("weather"),
+    ),
+    // update is pure: the root model is unchanged
+    check(getOr("-")(root.section), toBe("-")),
+  ]);
+});
+
+// --- The stack renders by depth --------------------
+
+const atRoot = renderToString(view(root));
+const atList = renderToString(
+  view({
+    base: "/",
+    section: some("botany"),
+    note: none(),
+    scheme: "light",
+  }),
+);
+const atReader = renderToString(
+  view({
+    base: "/",
+    section: some("botany"),
+    note: some("moss"),
+    scheme: "light",
+  }),
+);
+
+test("the stack pushes columns as the depth grows", () =>
+  all([
+    // root: only the nav column
+    check(
+      count(atRoot, 'class="pm-col'),
+      toBe(1),
+    ),
+    check(count(atRoot, "<nav"), toBe(1)),
+    check(atRoot.includes("<aside"), toBe(false)),
+    check(atRoot.includes("<main"), toBe(false)),
+    // + section: the list column appears
+    check(
+      count(atList, 'class="pm-col'),
+      toBe(2),
+    ),
+    check(count(atList, "<aside"), toBe(1)),
+    // + note: the reader column appears
+    check(
+      count(atReader, 'class="pm-col'),
+      toBe(3),
+    ),
+    check(count(atReader, "<main"), toBe(1)),
+  ]));
+
+test("pushed columns close by link (truncation is navigation)", () =>
+  all([
+    // list column closes to the root
+    check(
+      atList.includes(
+        'aria-label="Close Botany"',
+      ),
+      toBe(true),
+    ),
+    // reader closes to its section
+    check(
+      atReader.includes(
+        'aria-label="Close Moss on the north face"',
+      ),
+      toBe(true),
+    ),
+    check(
+      atReader.includes(
+        'href="/?s=botany" aria-label="Close Moss on the north face"',
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("the breadcrumb mirrors the stack", () =>
+  all([
+    check(
+      count(atReader, "ex-crumb-sep"),
+      toBe(2),
+    ),
+    check(
+      atReader.includes("ex-crumb-here"),
+      toBe(true),
+    ),
+    // parent crumbs are links to their truncating URLs
+    check(
+      atReader.includes(
+        'href="/" class="ex-crumb-link',
+      ),
+      toBe(true),
+    ),
+    check(
+      atReader.includes(
+        'href="/?s=botany" class="ex-crumb-link',
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("the selected note is marked and displayed", () =>
+  all([
+    // SSR escapes the query's & to &amp; in attributes
+    check(
+      atReader.includes(
+        `href="${noteHref("/", "botany", "moss").replace("&", "&amp;")}" aria-current="page"`,
+      ),
+      toBe(true),
+    ),
+    check(
+      atReader.includes("Moss on the north face"),
+      toBe(true),
+    ),
+  ]));
+
+test("the scheme class follows the model", () =>
+  all([
+    check(
+      atRoot.includes("ex-light"),
+      toBe(true),
+    ),
+    check(
+      renderToString(
+        view({ ...root, scheme: "dark" }),
+      ).includes("ex-dark"),
+      toBe(true),
+    ),
+  ]));
+
+test("scheme css carries both variable sets", () =>
+  all([
+    check(
+      schemeClassCss.includes(
+        ".ex-light{--pm-surface:",
+      ),
+      toBe(true),
+    ),
+    check(
+      schemeClassCss.includes(
+        ".ex-dark{--pm-surface:",
+      ),
+      toBe(true),
+    ),
+  ]));

--- a/packages/plggmatic-example/src/app.ts
+++ b/packages/plggmatic-example/src/app.ts
@@ -1,0 +1,691 @@
+import {
+  type SoftStr,
+  type Option,
+  some,
+  none,
+  matchOption,
+  getOr,
+} from "plgg";
+import {
+  type Html,
+  div,
+  slot,
+  ul,
+  li,
+  a,
+  span,
+  text,
+  attr,
+  href,
+  key,
+  fadeIn,
+} from "plgg-view";
+import {
+  type Application,
+  type Url,
+  makeUrl,
+} from "plgg-view/client";
+import {
+  type NavItem,
+  row,
+  column,
+  navPane,
+  mainPane,
+  asidePane,
+  heading,
+  prose,
+  themeToggle,
+  navTree,
+  focusRing,
+} from "plggmatic";
+// Namespaced so the Tailwind-style names (`p`, `text`, …)
+// coexist with the Html element builders imported above.
+import * as sx from "plggmatic/style";
+import {
+  type Section,
+  type Note,
+  sections,
+} from "./data.ts";
+
+/**
+ * The whole app state as one immutable value. The two
+ * selections are both `Option`s because the columns are
+ * a TRAVERSABLE STACK: no section means only the root
+ * column is on screen; selecting a section PUSHES the
+ * notes-list column; selecting a note pushes the reader.
+ * `base` is the mount path (captured from the entry URL,
+ * so the app works standalone at `/` and nested under
+ * the docs site at `/example/`). The stack depth is
+ * REFLECTED into the URL (`base` → `?s=…` → `?s=…&n=…`)
+ * by `toUrl`, so every arrangement is a shareable,
+ * back/forward-navigable address — the URL is the
+ * serialized column stack.
+ */
+export type Model = Readonly<{
+  base: SoftStr;
+  section: Option<SoftStr>;
+  note: Option<SoftStr>;
+  scheme: sx.Scheme;
+}>;
+
+/** Everything that can happen, as data. */
+export type Msg =
+  | Readonly<{ kind: "urlChanged"; url: Url }>
+  | Readonly<{ kind: "toggleScheme" }>;
+
+const findSection = (
+  id: SoftStr,
+): Option<Section> => {
+  const hit = sections.find((s) => s.id === id);
+  return hit === undefined ? none() : some(hit);
+};
+
+const currentSection = (
+  model: Model,
+): Option<Section> =>
+  matchOption<SoftStr, Option<Section>>(
+    () => none(),
+    findSection,
+  )(model.section);
+
+const currentNote = (
+  model: Model,
+): Option<Note> =>
+  matchOption<Section, Option<Note>>(
+    () => none(),
+    (section) =>
+      matchOption<SoftStr, Option<Note>>(
+        () => none(),
+        (noteId) => {
+          const hit = section.notes.find(
+            (n) => n.id === noteId,
+          );
+          return hit === undefined
+            ? none()
+            : some(hit);
+        },
+      )(model.note),
+  )(currentSection(model));
+
+// --- URL <-> Model (the pure codec) ---------------
+
+/** Canonical href for the root (sections only). */
+export const rootHref = (
+  base: SoftStr,
+): SoftStr => base;
+
+/** Canonical href for a section (pushes the list). */
+export const sectionHref = (
+  base: SoftStr,
+  id: SoftStr,
+): SoftStr =>
+  `${base}?s=${encodeURIComponent(id)}`;
+
+/** Canonical href for a note (pushes the reader). */
+export const noteHref = (
+  base: SoftStr,
+  sectionId: SoftStr,
+  noteId: SoftStr,
+): SoftStr =>
+  `${base}?s=${encodeURIComponent(sectionId)}&n=${encodeURIComponent(noteId)}`;
+
+/**
+ * Parses a Url into the stack depth, validating both ids
+ * against the dataset (an unknown id truncates the stack
+ * there rather than erroring — a URL is user input).
+ * Total: any string yields a Model slice.
+ */
+export const parseUrl = (
+  url: Url,
+): Readonly<{
+  section: Option<SoftStr>;
+  note: Option<SoftStr>;
+}> => {
+  const params = new URLSearchParams(url.search);
+  const rawSection = params.get("s");
+  const section: Option<SoftStr> =
+    rawSection === null
+      ? none()
+      : matchOption<Section, Option<SoftStr>>(
+          () => none(),
+          (s) => some(s.id),
+        )(findSection(rawSection));
+  const rawNote = params.get("n");
+  const note: Option<SoftStr> =
+    rawNote === null
+      ? none()
+      : matchOption<SoftStr, Option<SoftStr>>(
+          () => none(),
+          (sectionId) =>
+            matchOption<Section, Option<SoftStr>>(
+              () => none(),
+              (s) =>
+                s.notes.some(
+                  (n) => n.id === rawNote,
+                )
+                  ? some(rawNote)
+                  : none(),
+            )(findSection(sectionId)),
+        )(section);
+  return { section, note };
+};
+
+/**
+ * The model→URL projection (inverse of {@link parseUrl}).
+ * Canonical: equal models serialize to byte-equal URLs,
+ * which is what lets the runtime gate history writes on
+ * a string diff.
+ */
+export const toUrl = (model: Model): Url =>
+  makeUrl(
+    model.base,
+    matchOption<SoftStr, SoftStr>(
+      () => "",
+      (sectionId) =>
+        matchOption<SoftStr, SoftStr>(
+          () =>
+            `?s=${encodeURIComponent(sectionId)}`,
+          (noteId) =>
+            `?s=${encodeURIComponent(sectionId)}&n=${encodeURIComponent(noteId)}`,
+        )(model.note),
+    )(model.section),
+  );
+
+// --- The Elm program ------------------------------
+
+export const init = (url: Url): Model => ({
+  base: url.path,
+  ...parseUrl(url),
+  scheme: "light",
+});
+
+export const update = (
+  msg: Msg,
+  model: Model,
+): Model => {
+  switch (msg.kind) {
+    case "urlChanged":
+      return {
+        ...model,
+        ...parseUrl(msg.url),
+      };
+    case "toggleScheme":
+      return {
+        ...model,
+        scheme:
+          model.scheme === "light"
+            ? "dark"
+            : "light",
+      };
+  }
+};
+
+// --- View ------------------------------------------
+
+/**
+ * A column's sticky header chrome: the title, and (for
+ * pushed columns) a close link back to the truncating
+ * URL — leaving a column is the same gesture as entering
+ * one, a link. Styled by the app stylesheet
+ * (`.ex-colhead`), sticky over the column's own scroll.
+ */
+const colHead = (
+  title: SoftStr,
+  close: Option<SoftStr>,
+): Html<Msg> =>
+  slot(
+    [attr("class", "ex-colhead")],
+    [
+      span(
+        [attr("class", "ex-colhead-title")],
+        [text(title)],
+      ),
+      ...matchOption<
+        SoftStr,
+        ReadonlyArray<Html<Msg>>
+      >(
+        () => [],
+        (to) => [
+          a(
+            [
+              href(to),
+              attr(
+                "aria-label",
+                `Close ${title}`,
+              ),
+              // the class hook rides style_ (the sole
+              // class authority): a separate class attr
+              // would be clobbered by the atomic classes
+              sx.style_("ex-close", focusRing),
+            ],
+            [text("×")],
+          ),
+        ],
+      )(close),
+    ],
+  );
+
+/**
+ * The root column: the section menu. Always on screen —
+ * the anchor of the stack.
+ */
+const sectionsColumn = (
+  model: Model,
+): Html<Msg> => {
+  const navItems: ReadonlyArray<NavItem> =
+    sections.map((s) => ({
+      label: s.label,
+      href: some(sectionHref(model.base, s.id)),
+      children: [],
+    }));
+  const active = matchOption<SoftStr, SoftStr>(
+    () => "",
+    (id) => sectionHref(model.base, id),
+  )(model.section);
+  return column(
+    [sx.basis("220px")],
+    [
+      navPane(
+        [],
+        [
+          colHead("Sections", none()),
+          div(
+            [sx.style_(sx.p(2))],
+            [navTree(navItems, active)],
+          ),
+        ],
+      ),
+    ],
+  );
+};
+
+/**
+ * The list column, pushed when a section is selected.
+ * Keyed by the section id so switching sections remounts
+ * it fresh (and replays the entrance fade).
+ */
+const listColumn = (
+  model: Model,
+  section: Section,
+): Html<Msg> => {
+  const selected = getOr("")(model.note);
+  const noteLink = (
+    note: Note,
+  ): Html<Msg, "li"> =>
+    li(
+      [],
+      [
+        a(
+          [
+            href(
+              noteHref(
+                model.base,
+                section.id,
+                note.id,
+              ),
+            ),
+            ...(selected === note.id
+              ? [attr("aria-current", "page")]
+              : []),
+            sx.style_(
+              sx.block,
+              sx.textColor("text"),
+              sx.px(2),
+              sx.py(1),
+              sx.rounded("sm"),
+              focusRing,
+            ),
+          ],
+          [text(note.title)],
+        ),
+      ],
+    );
+  return column(
+    [sx.basis("300px")],
+    [
+      asidePane(
+        [],
+        [
+          slot(
+            [
+              key(`list-${section.id}`),
+              fadeIn(150),
+            ],
+            [
+              colHead(
+                section.label,
+                some(rootHref(model.base)),
+              ),
+              ul(
+                [
+                  sx.style_(
+                    sx.listNone,
+                    sx.m(0),
+                    sx.p(2),
+                  ),
+                ],
+                section.notes.map(noteLink),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+};
+
+/**
+ * The reader column, pushed when a note is selected.
+ * Keyed by the note id: choosing another note remounts
+ * the reader (fresh scroll position, entrance fade).
+ */
+const readerColumn = (
+  model: Model,
+  section: Section,
+  note: Note,
+): Html<Msg> =>
+  column(
+    ["ex-reader", sx.fluid],
+    [
+      mainPane(
+        [],
+        [
+          slot(
+            [
+              key(`reader-${note.id}`),
+              fadeIn(150),
+            ],
+            [
+              colHead(
+                note.title,
+                some(
+                  sectionHref(
+                    model.base,
+                    section.id,
+                  ),
+                ),
+              ),
+              slot(
+                [
+                  sx.style_(
+                    sx.p(4),
+                    sx.maxW(176),
+                  ),
+                ],
+                [
+                  heading(1, note.title),
+                  prose(
+                    note.body.map((paragraph) =>
+                      div(
+                        [sx.style_(sx.mb(3))],
+                        [text(paragraph)],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+
+/**
+ * The workbench as a TRAVERSABLE COLUMN STACK — the
+ * dynamic reading of column-oriented layout, written
+ * compositionally: the stack is a `row` of `column`s
+ * derived from the depth. The root sections column is
+ * always present, the list column is pushed by a section
+ * selection, the reader by a note selection. Truncation
+ * is a link too (each pushed column's × links to the
+ * shallower URL), so the whole stack stays modeless and
+ * back/forward-navigable. No layout config object — the
+ * geometry is the composed atoms.
+ */
+export const stack = (
+  model: Model,
+): Html<Msg> => {
+  const pushed: ReadonlyArray<Html<Msg>> =
+    matchOption<
+      Section,
+      ReadonlyArray<Html<Msg>>
+    >(
+      () => [],
+      (section) => [
+        listColumn(model, section),
+        ...matchOption<
+          Note,
+          ReadonlyArray<Html<Msg>>
+        >(
+          () => [],
+          (note) => [
+            readerColumn(model, section, note),
+          ],
+        )(currentNote(model)),
+      ],
+    )(currentSection(model));
+  return row(
+    [],
+    [sectionsColumn(model), ...pushed],
+  );
+};
+
+/**
+ * The breadcrumb trail in the top bar: one crumb per
+ * column on the stack. Every crumb except the last is a
+ * link to the URL that truncates the stack there —
+ * navigation, not a mode switch. Mirrors the column
+ * headers so the trail stays legible when columns scroll
+ * off on narrow screens.
+ */
+const breadcrumb = (model: Model): Html<Msg> => {
+  const sectionCrumb = matchOption<
+    Section,
+    ReadonlyArray<
+      Readonly<{
+        label: SoftStr;
+        to: Option<SoftStr>;
+      }>
+    >
+  >(
+    () => [],
+    (section) => [
+      {
+        label: section.label,
+        to: some(
+          sectionHref(model.base, section.id),
+        ),
+      },
+    ],
+  )(currentSection(model));
+  const noteCrumb = matchOption<
+    Note,
+    ReadonlyArray<
+      Readonly<{
+        label: SoftStr;
+        to: Option<SoftStr>;
+      }>
+    >
+  >(
+    () => [],
+    (note) => [{ label: note.title, to: none() }],
+  )(currentNote(model));
+  const crumbs = [
+    {
+      label: "Sections",
+      to: some(rootHref(model.base)),
+    },
+    ...sectionCrumb,
+    ...noteCrumb,
+  ];
+  const last = crumbs.length - 1;
+  return slot(
+    [
+      attr("class", "ex-crumbs"),
+      attr("aria-label", "You are here"),
+    ],
+    crumbs.flatMap((crumb, i) => {
+      const label =
+        i === last
+          ? span(
+              [attr("class", "ex-crumb-here")],
+              [text(crumb.label)],
+            )
+          : matchOption<SoftStr, Html<Msg>>(
+              () => span([], [text(crumb.label)]),
+              (to) =>
+                a(
+                  [
+                    href(to),
+                    sx.style_(
+                      "ex-crumb-link",
+                      focusRing,
+                    ),
+                  ],
+                  [text(crumb.label)],
+                ),
+            )(crumb.to);
+      return i === 0
+        ? [label]
+        : [
+            span(
+              [
+                attr("class", "ex-crumb-sep"),
+                attr("aria-hidden", "true"),
+              ],
+              [text("›")],
+            ),
+            label,
+          ];
+    }),
+  );
+};
+
+/**
+ * The top bar: wordmark, the breadcrumb trail, and the
+ * scheme toggle. Sits above the column strip; the app
+ * stylesheet trims the strip's viewport height to match.
+ */
+const topBar = (model: Model): Html<Msg> =>
+  slot(
+    [attr("class", "ex-header")],
+    [
+      span(
+        [attr("class", "ex-brand")],
+        [text("Field Notes")],
+      ),
+      breadcrumb(model),
+      span([attr("class", "ex-spacer")], []),
+      themeToggle<Msg>({
+        scheme: model.scheme,
+        toggle: { kind: "toggleScheme" },
+      }),
+    ],
+  );
+
+/**
+ * The view: top bar + column strip, wrapped in a scheme
+ * class carrier. The framework's contract leaves
+ * applying the scheme to the consuming app; this app
+ * carries the `--pm-*` variable sets on
+ * `.ex-light`/`.ex-dark` (see {@link schemeClassCss})
+ * and swaps the class from pure state — no DOM mutation
+ * anywhere.
+ */
+export const view = (model: Model): Html<Msg> =>
+  slot(
+    [attr("class", `ex-root ex-${model.scheme}`)],
+    [topBar(model), stack(model)],
+  );
+
+// --- Static CSS ------------------------------------
+
+/**
+ * The `--pm-*` variable sets scoped to the app root's
+ * scheme classes, generated from the framework's own
+ * palette (`colorHex`) — values stay in one place
+ * upstream; this app only re-scopes them so the scheme
+ * can be swapped by pure re-render instead of a
+ * document-level class mutation.
+ */
+export const schemeClassCss: SoftStr = sx.schemes
+  .map(
+    (scheme) =>
+      `.ex-${scheme}{${sx.colors
+        .map(
+          (c) =>
+            `--pm-${c}:${sx.colorHex(scheme, c)};`,
+        )
+        .join("")}}`,
+  )
+  .join("");
+
+// The top bar's fixed height; the column strip fills the
+// rest of the viewport (see the media override below).
+const HEADER_H = "48px";
+
+/**
+ * The app's own chrome on top of the framework
+ * geometry: the top bar, the sticky column headers, the
+ * inverted-pill active state (one rule serves the nav
+ * tree and the note list — anything marked
+ * `aria-current`), column panel surfaces, the strip's
+ * viewport height (minus the top bar) with per-column
+ * scroll on wide screens, and the below-breakpoint
+ * horizontal snap strip. All geometry beyond the
+ * composed atoms lives here, targeting the combinators'
+ * `pm-row`/`pm-col`/`pm-pane` hooks.
+ */
+const chromeCss: SoftStr =
+  `.ex-header{display:flex;align-items:center;gap:0.75rem;height:${HEADER_H};padding:0 1rem;background:var(--pm-surface);border-bottom:1px solid var(--pm-border);}` +
+  `.ex-brand{font-weight:600;white-space:nowrap;}` +
+  `.ex-crumbs{display:flex;align-items:center;gap:0.4rem;min-width:0;overflow:hidden;white-space:nowrap;font-size:0.85rem;color:var(--pm-muted);}` +
+  `.ex-crumbs a{color:var(--pm-muted);text-decoration:none;padding:0.15rem 0.4rem;border-radius:0.25rem;}` +
+  `.ex-crumbs a:hover{background:var(--pm-primary);color:var(--pm-primary-text);}` +
+  `.ex-crumb-here{color:var(--pm-text);font-weight:500;overflow:hidden;text-overflow:ellipsis;}` +
+  `.ex-crumb-sep{color:var(--pm-border);}` +
+  `.ex-spacer{flex:1 1 auto;}` +
+  `.pm-row{background:var(--pm-surface-2);}` +
+  `.pm-col{background:var(--pm-surface);border-right:1px solid var(--pm-border);}` +
+  `.ex-colhead{position:sticky;top:0;z-index:1;display:flex;align-items:center;justify-content:space-between;gap:0.5rem;height:40px;padding:0 0.75rem;background:var(--pm-surface-2);border-bottom:1px solid var(--pm-border);}` +
+  `.ex-colhead-title{font-size:0.85rem;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}` +
+  `.ex-close{color:var(--pm-muted);text-decoration:none;line-height:1;padding:0.25rem 0.4rem;border-radius:0.25rem;}` +
+  `.ex-close:hover{background:var(--pm-primary);color:var(--pm-primary-text);}` +
+  `.pm-pane a[aria-current="page"]{background:var(--pm-primary);color:var(--pm-primary-text);}` +
+  `@media (min-width:900px){.pm-row{height:calc(100vh - ${HEADER_H});overflow:hidden;}.pm-col{height:calc(100vh - ${HEADER_H});overflow-y:auto;}}` +
+  `@media (max-width:899px){.pm-row{overflow-x:auto;scroll-snap-type:x proximity;}.pm-col{scroll-snap-align:start;}.ex-reader{min-width:88vw;}}`;
+
+/**
+ * The app's whole static stylesheet: baseline reset,
+ * scheme variables, and the app chrome. The composed
+ * atoms (basis/fluid, spacing, colors) travel WITH the
+ * elements through the runtime's own sheet — the static
+ * layer holds only what atoms cannot express (the
+ * `@media` responsiveness and the app chrome). Injected
+ * once at boot by the client entry.
+ */
+export const appCss: SoftStr =
+  `body{margin:0;font-family:system-ui,sans-serif;line-height:1.6;}` +
+  `.ex-root{background:var(--pm-surface);color:var(--pm-text);min-height:100vh;}` +
+  `.ex-root a{text-decoration:none;}` +
+  schemeClassCss +
+  chromeCss;
+
+/** The wired program the client entry mounts. */
+export const app: Application<Model, Msg> = {
+  init,
+  update,
+  view,
+  onUrlChange: (url) => ({
+    kind: "urlChanged",
+    url,
+  }),
+  toUrl,
+  historyMode: (prev, next) =>
+    getOr("")(prev.section) !==
+      getOr("")(next.section) ||
+    getOr("")(prev.note) !== getOr("")(next.note)
+      ? "push"
+      : "none",
+};

--- a/packages/plggmatic-example/src/data.ts
+++ b/packages/plggmatic-example/src/data.ts
@@ -1,0 +1,95 @@
+import { type SoftStr } from "plgg";
+
+/**
+ * The demo dataset: field notes grouped into sections.
+ * Pure data — the app is a browser over it. Everything
+ * else (columns, selection, scheme) is derived state.
+ */
+export type Note = Readonly<{
+  id: SoftStr;
+  title: SoftStr;
+  body: ReadonlyArray<SoftStr>;
+}>;
+
+export type Section = Readonly<{
+  id: SoftStr;
+  label: SoftStr;
+  notes: ReadonlyArray<Note>;
+}>;
+
+export const sections: ReadonlyArray<Section> = [
+  {
+    id: "botany",
+    label: "Botany",
+    notes: [
+      {
+        id: "moss",
+        title: "Moss on the north face",
+        body: [
+          "The retaining wall's north face carries a continuous moss mat; the south face is bare.",
+          "Moisture, not light, appears to be the deciding variable — the mat follows the drainage seam.",
+        ],
+      },
+      {
+        id: "maple",
+        title: "Maple seedlings in the gutter",
+        body: [
+          "Six seedlings rooted in composted leaf litter, all first-year.",
+          "The gutter is effectively a nursery bed: shaded, damp, and undisturbed.",
+        ],
+      },
+      {
+        id: "lichen",
+        title: "Lichen ring dating",
+        body: [
+          "The largest ring on the bench stone measures 92mm across.",
+          "At the usual growth rate that puts colonization near the bench's installation year.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "geology",
+    label: "Geology",
+    notes: [
+      {
+        id: "strata",
+        title: "Cut-bank strata",
+        body: [
+          "The stream's cut bank exposes three clear bands: topsoil, red clay, and a gravel lens.",
+          "The gravel lens carries water after rain — the seep line marks its lower boundary.",
+        ],
+      },
+      {
+        id: "erratic",
+        title: "The erratic by the gate",
+        body: [
+          "A rounded granite boulder in a landscape of sedimentary rock.",
+          "Nothing nearby could have produced it; it was carried here, most plausibly by ice.",
+        ],
+      },
+    ],
+  },
+  {
+    id: "weather",
+    label: "Weather",
+    notes: [
+      {
+        id: "fog",
+        title: "Fog pooling in the hollow",
+        body: [
+          "On still mornings the fog fills the hollow to a consistent height, like water.",
+          "The tree line marks the inversion layer almost exactly.",
+        ],
+      },
+      {
+        id: "frost",
+        title: "First frost map",
+        body: [
+          "Frost lands first on the open lawn, last under the oak canopy.",
+          "The canopy's outline is legible in the frost pattern a full hour after sunrise.",
+        ],
+      },
+    ],
+  },
+];

--- a/packages/plggmatic-example/src/main.ts
+++ b/packages/plggmatic-example/src/main.ts
@@ -1,0 +1,29 @@
+import {
+  pipe,
+  fromNullable,
+  mapOption,
+} from "plgg";
+import { application } from "plgg-view/client";
+import { app, appCss } from "./app.ts";
+
+/**
+ * CSR entry — the only side-effecting module. Injects
+ * the app's static stylesheet (baseline + scheme
+ * variables + shell geometry; the atomic per-element
+ * rules are managed by the runtime's own sheet) and
+ * mounts the workbench program onto `#root`.
+ * `application` (not `sandbox`) so the runtime owns the
+ * URL: the section/note selections are reflected to the
+ * address bar and seeded back from a deep link, and
+ * back/forward walks the selection history.
+ */
+const style = document.createElement("style");
+style.textContent = appCss;
+document.head.appendChild(style);
+
+pipe(
+  fromNullable(document.getElementById("root")),
+  mapOption((root: HTMLElement) =>
+    application(app)(root),
+  ),
+);

--- a/packages/plggmatic-example/src/stamp.ts
+++ b/packages/plggmatic-example/src/stamp.ts
@@ -1,0 +1,43 @@
+/**
+ * Build-time cache-buster (run by `npm run build` after
+ * the bundle is written): stamps the bundle's content
+ * hash into the module URL in `dist/index.html`
+ * (`./main.js?v=<hash>`). Intermediaries cache `.js`
+ * aggressively (a CDN edge in front of this app caches
+ * scripts by default but not HTML), so a fresh HTML must
+ * point at a URL that misses the cache whenever the
+ * bundle's bytes change — same-content rebuilds keep the
+ * same URL and stay cached.
+ */
+import {
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+const root = process.cwd();
+const bundle = readFileSync(
+  join(root, "dist", "main.js"),
+);
+const hash = createHash("sha256")
+  .update(bundle)
+  .digest("hex")
+  .slice(0, 8);
+// Target the script src attribute specifically — a bare
+// "./main.js" replace would hit the explanatory comment
+// above the mount point first and stamp that instead.
+const html = readFileSync(
+  join(root, "index.html"),
+  "utf8",
+).replace(
+  'src="./main.js"',
+  `src="./main.js?v=${hash}"`,
+);
+writeFileSync(
+  join(root, "dist", "index.html"),
+  html,
+);
+console.log(
+  `stamp: dist/index.html -> ./main.js?v=${hash}`,
+);

--- a/packages/plggmatic-example/tsconfig.json
+++ b/packages/plggmatic-example/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    /* Compiler Option */
+    "target": "ES2021",
+    /* A leaf CSR app: `"type": "module"`, run directly via
+       Node type-stripping (plgg-test), bundled by
+       plgg-bundle. DOM lib because the client entry mounts
+       onto document; relative imports carry the .ts
+       extension (erasableSyntaxOnly). */
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "sourceMap": false,
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "rootDir": "src",
+    "types": ["node"],
+    /* Type Checking Rules */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowJs": false,
+    "erasableSyntaxOnly": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/plggmatic/.prettierrc.json
+++ b/packages/plggmatic/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 50,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSameLine": false
+}

--- a/packages/plggmatic/README.md
+++ b/packages/plggmatic/README.md
@@ -1,0 +1,20 @@
+# plggmatic
+
+> **UNSTABLE** - Experimental study work. Part of the [plgg monorepo](../../README.md).
+
+A **column-oriented UI design framework** on the plgg family: a typed light/dark
+**color scheme** (roles resolved through `var(--pm-*)` custom properties, so one
+`dark` class reschemes the whole tree), **layout combinators** (`row` / `column`
+/ `pane`) composed like element builders take `(parts, children)`, and
+**fundamental components** as pure `(props) => Html<Msg>`. Styling is data —
+atoms composed through [plgg-view](../plgg-view/)'s `style_`, gathered by
+`collectCss`. No layout config object and no runtime to boot.
+
+The vocabulary is one word per concept: **Column**, **Pane**, **Alignment**,
+**Token**, **Scheme**. The design system is emergent — seeded minimal, one
+recorded rule per component.
+
+This is the UI design framework — distinct from the app-framework facade that
+[plggpress](../plggpress/) absorbed. See the documentation site in
+[`packages/site/`](../site/) and the workbench demo in
+[`packages/plggmatic-example/`](../plggmatic-example/).

--- a/packages/plggmatic/bundle.config.ts
+++ b/packages/plggmatic/bundle.config.ts
@@ -1,0 +1,27 @@
+// In-house bundler config for plggmatic. ESM-only output:
+// the package declares `"type": "module"`, so a `.cjs.js`
+// sibling would be mis-read as ESM by Node. The style
+// entry's OUTPUT KEY is `styleEntry` (not `style`) so
+// `dist/styleEntry.*` cannot case-collide with a future
+// `dist/Style/` declaration tree on a case-insensitive
+// filesystem; the published `./style` subpath points at
+// it. Externals (the plgg family + node:*) are derived
+// from package.json, never listed here.
+export default {
+  root: import.meta.dirname,
+  rootDir: "src",
+  outDir: "dist",
+  entries: [
+    { name: "index", input: "index.ts" },
+    {
+      name: "styleEntry",
+      input: "styleEntry.ts",
+    },
+  ],
+  formats: ["es"],
+  fileNamePattern: "[name].[format].js",
+  alias: {
+    prefix: "plggmatic",
+    srcRoot: "src",
+  },
+};

--- a/packages/plggmatic/package-lock.json
+++ b/packages/plggmatic/package-lock.json
@@ -1,0 +1,186 @@
+{
+  "name": "plggmatic",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plggmatic",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "plgg-view": "file:../plgg-view"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plgg": {
+      "version": "0.0.27",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plgg-bundle": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-bundle": "bin/plgg-bundle.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-test": "file:../plgg-test"
+      }
+    },
+    "../../../plgg/packages/plgg-test": {
+      "version": "0.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-test": "bin/plgg-test.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle"
+      },
+      "engines": {
+        "node": ">=22.6"
+      }
+    },
+    "../../../plgg/packages/plgg-view": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plgg": {
+      "version": "0.0.27",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plgg-bundle": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-bundle": "bin/plgg-bundle.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-test": "file:../plgg-test"
+      }
+    },
+    "../plgg-test": {
+      "version": "0.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-test": "bin/plgg-test.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle"
+      },
+      "engines": {
+        "node": ">=22.6"
+      }
+    },
+    "../plgg-view": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/plgg": {
+      "resolved": "../plgg",
+      "link": true
+    },
+    "node_modules/plgg-bundle": {
+      "resolved": "../plgg-bundle",
+      "link": true
+    },
+    "node_modules/plgg-test": {
+      "resolved": "../plgg-test",
+      "link": true
+    },
+    "node_modules/plgg-view": {
+      "resolved": "../plgg-view",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/plggmatic/package.json
+++ b/packages/plggmatic/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "plggmatic",
+  "version": "0.1.0",
+  "description": "A column-oriented UI design framework on the plgg family: pane alignment, a typed light/dark color scheme, and fundamental components as pure functions returning plgg-view Html",
+  "type": "module",
+  "main": "dist/index.es.js",
+  "module": "dist/index.es.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.es.js"
+    },
+    "./style": {
+      "types": "./dist/styleEntry.d.ts",
+      "default": "./dist/styleEntry.es.js"
+    }
+  },
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "plgg-bundle",
+    "test": "tsc --noEmit && plgg-test src",
+    "tsc": "tsc --noEmit",
+    "tsc:watch": "tsc --noEmit --watch",
+    "test:watch": "plgg-test src --watch",
+    "coverage": "tsc --noEmit && plgg-test src --coverage",
+    "coverage:watch": "plgg-test src --coverage --watch",
+    "publish": "npm run build && npm publish"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qmu/plggmatic.git"
+  },
+  "author": "qmu",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/qmu/plggmatic/issues"
+  },
+  "homepage": "https://github.com/qmu/plggmatic#readme",
+  "dependencies": {
+    "plgg": "file:../plgg",
+    "plgg-view": "file:../plgg-view"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "plgg-bundle": "file:../plgg-bundle",
+    "plgg-test": "file:../plgg-test",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/plggmatic/plgg-test.config.json
+++ b/packages/plggmatic/plgg-test.config.json
@@ -1,0 +1,9 @@
+{
+  "coverage": {
+    "threshold": 90,
+    "exclude": [
+      "/index.ts",
+      "/styleEntry.ts"
+    ]
+  }
+}

--- a/packages/plggmatic/src/Component/index.ts
+++ b/packages/plggmatic/src/Component/index.ts
@@ -1,0 +1,37 @@
+/**
+ * The plggmatic Component module: the seed set of
+ * fundamental components, each a pure `(props) =>
+ * Html<Msg>` styled through the token utilities, each
+ * carrying exactly one recorded interaction rule (see
+ * each function's doc comment). An explicit named barrel
+ * (house style); the set is deliberately small — form
+ * controls, tables, and overlays arrive in later
+ * tickets, each with its own rule. The shared
+ * interaction-state vocabulary is defined once in
+ * `model/interaction` and imported by all.
+ */
+export {
+  type InteractionState,
+  focusRing,
+  hoverDim,
+  pressDim,
+} from "plggmatic/Component/model/interaction";
+export {
+  type ButtonProps,
+  button,
+} from "plggmatic/Component/usecase/button";
+export {
+  type TextLinkProps,
+  textLink,
+} from "plggmatic/Component/usecase/textLink";
+export {
+  type HeadingLevel,
+  heading,
+  prose,
+} from "plggmatic/Component/usecase/typography";
+export {
+  type ThemeToggleProps,
+  themeToggle,
+} from "plggmatic/Component/usecase/themeToggle";
+export { type NavItem } from "plggmatic/Component/model/navItem";
+export { navTree } from "plggmatic/Component/usecase/navTree";

--- a/packages/plggmatic/src/Component/model/interaction.ts
+++ b/packages/plggmatic/src/Component/model/interaction.ts
@@ -1,0 +1,56 @@
+import {
+  type Variant,
+  outline,
+  decl,
+} from "plggmatic/styleEntry";
+
+/**
+ * The standardized interaction states every plggmatic
+ * component speaks — defined ONCE here and imported by
+ * all, so a button, a link, and a toggle give identical
+ * feedback for the same gesture (interaction-design
+ * standard). A closed union; a component that invents a
+ * new state must add it here, with a rule, not inline.
+ */
+export type InteractionState =
+  | "default"
+  | "hover"
+  | "focus"
+  | "active"
+  | "disabled";
+
+/**
+ * THE recorded interaction rule of the framework, shared
+ * by every focusable component: a keyboard focus ring
+ * that is a real 2px outline offset from the control —
+ * a NON-COLOR affordance (geometry, not just a hue), so
+ * focus is legible independent of color vision
+ * (accessibility-first). Scoped to `:focus-visible` so
+ * it appears for keyboard/AT focus but not on mouse
+ * press. The ring color is the themed `primary` role, so
+ * it reschemes with the UI.
+ */
+export const focusRing: Variant = {
+  selector: ":focus-visible",
+  styles: [
+    ...outline("primary"),
+    ...decl("outline-offset", "2px"),
+  ],
+};
+
+/**
+ * Shared hover feedback: a slight dim. Kept as opacity
+ * (not a new hover color token) so every component dims
+ * consistently without expanding the palette before a
+ * component needs a dedicated hover role.
+ */
+export const hoverDim: Variant = {
+  selector: ":hover",
+  styles: decl("opacity", "0.9"),
+};
+
+/** Shared press feedback: a deeper dim on `:active`. */
+export const pressDim: Variant = {
+  selector: ":active",
+  styles: decl("opacity", "0.8"),
+};

--- a/packages/plggmatic/src/Component/model/navItem.ts
+++ b/packages/plggmatic/src/Component/model/navItem.ts
@@ -1,0 +1,16 @@
+import { type SoftStr, type Option } from "plgg";
+
+/**
+ * One node of a {@link navTree}. `href` is an `Option`
+ * (not a nullable string): a `Some` renders a link, a
+ * `None` renders a plain section-header label — so a
+ * group heading and a leaf link are one recursive type,
+ * and "a heading with no link" is expressed in the type,
+ * not by an empty string. `children` recurses; a leaf
+ * has `[]`.
+ */
+export type NavItem = Readonly<{
+  label: SoftStr;
+  href: Option<SoftStr>;
+  children: ReadonlyArray<NavItem>;
+}>;

--- a/packages/plggmatic/src/Component/usecase/button.spec.ts
+++ b/packages/plggmatic/src/Component/usecase/button.spec.ts
@@ -1,0 +1,91 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  renderToString,
+  collectCss,
+} from "plgg-view";
+import { button } from "plggmatic/Component/usecase/button";
+
+const enabled = button({
+  label: "Save",
+  onPress: "save",
+  disabled: false,
+});
+const disabled = button({
+  label: "Save",
+  onPress: "save",
+  disabled: true,
+});
+
+test("button is a real <button type=button>", () =>
+  all([
+    check(
+      renderToString(enabled).startsWith(
+        "<button",
+      ),
+      toBe(true),
+    ),
+    check(
+      renderToString(enabled).includes(
+        'type="button"',
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("disabled uses the native attribute", () =>
+  all([
+    check(
+      renderToString(disabled).includes(
+        "disabled",
+      ),
+      toBe(true),
+    ),
+    check(
+      renderToString(enabled).includes(
+        "disabled",
+      ),
+      toBe(false),
+    ),
+  ]));
+
+test("focus + disabled differ by a non-color declaration", () =>
+  all([
+    // focus adds a geometric outline the default lacks
+    check(
+      collectCss(enabled).includes(
+        ":focus-visible{outline:2px solid var(--pm-primary)",
+      ),
+      toBe(true),
+    ),
+    // disabled swaps the cursor (non-color) vs the
+    // enabled pointer
+    check(
+      collectCss(enabled).includes(
+        "cursor:pointer",
+      ),
+      toBe(true),
+    ),
+    check(
+      collectCss(disabled).includes(
+        "cursor:not-allowed",
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("button is pure", () =>
+  check(
+    renderToString(
+      button({
+        label: "Save",
+        onPress: "save",
+        disabled: false,
+      }),
+    ),
+    toBe(renderToString(enabled)),
+  ));

--- a/packages/plggmatic/src/Component/usecase/button.ts
+++ b/packages/plggmatic/src/Component/usecase/button.ts
@@ -1,0 +1,77 @@
+import { type SoftStr } from "plgg";
+import {
+  type Html,
+  button as buttonEl,
+  text,
+  attr,
+  type_,
+  onClick,
+} from "plgg-view";
+import {
+  style_,
+  bg,
+  textColor,
+  px,
+  py,
+  rounded,
+  weight,
+  pointer,
+  decl,
+} from "plggmatic/styleEntry";
+import {
+  focusRing,
+  hoverDim,
+  pressDim,
+} from "plggmatic/Component/model/interaction";
+
+/**
+ * A button's props. `onPress` is the typed `Msg` the
+ * click produces (components are pure views — no
+ * internal state); `disabled` is a real boolean, not a
+ * styled look-alike.
+ */
+export type ButtonProps<Msg> = Readonly<{
+  label: SoftStr;
+  onPress: Msg;
+  disabled: boolean;
+}>;
+
+/**
+ * The action component. **Recorded rule**: an action is
+ * always a real `<button type="button">` (never a
+ * div-with-onclick), and `disabled` is conveyed by MORE
+ * than color — the native `disabled` attribute (which
+ * also drops it from the tab order) plus a
+ * `cursor:not-allowed` and reduced opacity, and the
+ * hover/press feedback is withheld. Enabled buttons
+ * carry the shared {@link focusRing}/{@link
+ * hoverDim}/{@link pressDim} state set. Styled only
+ * through token utilities.
+ */
+export const button = <Msg>(
+  props: ButtonProps<Msg>,
+): Html<Msg, "button"> =>
+  buttonEl(
+    [
+      type_("button"),
+      ...(props.disabled
+        ? [attr("disabled", "")]
+        : [onClick(props.onPress)]),
+      style_(
+        bg("primary"),
+        textColor("primary-text"),
+        px(4),
+        py(2),
+        rounded("md"),
+        weight(500),
+        focusRing,
+        ...(props.disabled
+          ? [
+              decl("cursor", "not-allowed"),
+              decl("opacity", "0.6"),
+            ]
+          : [pointer, hoverDim, pressDim]),
+      ),
+    ],
+    [text(props.label)],
+  );

--- a/packages/plggmatic/src/Component/usecase/navTree.spec.ts
+++ b/packages/plggmatic/src/Component/usecase/navTree.spec.ts
@@ -1,0 +1,78 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import { some, none } from "plgg";
+import { renderToString } from "plgg-view";
+import { type NavItem } from "plggmatic/Component/model/navItem";
+import { navTree } from "plggmatic/Component/usecase/navTree";
+
+// A group header (no link) over two leaves; one of them
+// is the active page.
+const items: ReadonlyArray<NavItem> = [
+  {
+    label: "Guide",
+    href: none(),
+    children: [
+      {
+        label: "Intro",
+        href: some("/guide/intro"),
+        children: [],
+      },
+      {
+        label: "Tokens",
+        href: some("/guide/tokens"),
+        children: [],
+      },
+    ],
+  },
+];
+
+const rendered = renderToString(
+  navTree(items, "/guide/tokens"),
+);
+
+test("navTree is list markup, not a nested landmark", () =>
+  all([
+    // list-rooted, so the Layout nav pane owns the
+    // landmark (no nested <nav>)
+    check(rendered.startsWith("<ul"), toBe(true)),
+    check(rendered.includes("<nav"), toBe(false)),
+    check(rendered.includes("<li"), toBe(true)),
+  ]));
+
+test("the active leaf is marked at build time", () =>
+  all([
+    check(
+      rendered.includes(
+        'href="/guide/tokens" aria-current="page"',
+      ),
+      toBe(true),
+    ),
+    // the non-active leaf carries no aria-current
+    check(
+      rendered.includes(
+        'href="/guide/intro" aria-current',
+      ),
+      toBe(false),
+    ),
+  ]));
+
+test("a link-less header renders as plain text, not a link", () =>
+  all([
+    check(rendered.includes("<span"), toBe(true)),
+    check(
+      rendered.includes(">Guide<"),
+      toBe(true),
+    ),
+  ]));
+
+test("navTree is pure", () =>
+  check(
+    renderToString(
+      navTree(items, "/guide/tokens"),
+    ),
+    toBe(rendered),
+  ));

--- a/packages/plggmatic/src/Component/usecase/navTree.ts
+++ b/packages/plggmatic/src/Component/usecase/navTree.ts
@@ -1,0 +1,89 @@
+import { type SoftStr, matchOption } from "plgg";
+import {
+  type Html,
+  type Flow,
+  ul,
+  li,
+  a,
+  span,
+  text,
+  attr,
+  href,
+} from "plgg-view";
+import {
+  style_,
+  textColor,
+  listNone,
+  p,
+  pl,
+} from "plggmatic/styleEntry";
+import {
+  focusRing,
+  hoverDim,
+} from "plggmatic/Component/model/interaction";
+import { type NavItem } from "plggmatic/Component/model/navItem";
+
+/**
+ * The navigation-tree component: a recursive,
+ * config-driven tree (the docs-site sidebar). **Recorded
+ * rule**: navTree emits LIST markup only — a `<ul>` of
+ * `<li>`, nested for children — and does NOT wrap itself
+ * in a `<nav>` landmark; the landmark is owned by the
+ * Layout `navigation` pane it sits inside, so the two
+ * never produce nested/duplicate nav landmarks (the
+ * higher-level pane policy wins, per this ticket's
+ * coordination note). The leaf whose `href` equals
+ * `activePath` is marked `aria-current="page"` at build
+ * time; a header node (`href` `None`) renders plain
+ * text. Zero client JavaScript — the whole tree is
+ * static SSR. Links carry the shared focus ring and
+ * hover feedback.
+ */
+export const navTree = (
+  items: ReadonlyArray<NavItem>,
+  activePath: SoftStr,
+): Html<never, "ul"> => {
+  const label = (item: NavItem): Flow<never> =>
+    matchOption<SoftStr, Flow<never>>(
+      () =>
+        span(
+          [style_(textColor("muted"))],
+          [text(item.label)],
+        ),
+      (to) =>
+        a(
+          [
+            href(to),
+            ...(to === activePath
+              ? [attr("aria-current", "page")]
+              : []),
+            style_(
+              textColor("text"),
+              focusRing,
+              hoverDim,
+            ),
+          ],
+          [text(item.label)],
+        ),
+    )(item.href);
+
+  const renderItem = (
+    item: NavItem,
+  ): Html<never, "li"> =>
+    li(
+      [],
+      item.children.length === 0
+        ? [label(item)]
+        : [label(item), list(item.children)],
+    );
+
+  const list = (
+    nodes: ReadonlyArray<NavItem>,
+  ): Html<never, "ul"> =>
+    ul(
+      [style_(listNone, p(0), pl(3))],
+      nodes.map(renderItem),
+    );
+
+  return list(items);
+};

--- a/packages/plggmatic/src/Component/usecase/textLink.spec.ts
+++ b/packages/plggmatic/src/Component/usecase/textLink.spec.ts
@@ -1,0 +1,83 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  renderToString,
+  collectCss,
+} from "plgg-view";
+import { textLink } from "plggmatic/Component/usecase/textLink";
+
+const internal = textLink({
+  label: "Docs",
+  to: "/docs",
+  external: false,
+});
+const external = textLink({
+  label: "GitHub",
+  to: "https://github.com/qmu/plggmatic",
+  external: true,
+});
+
+test("textLink is a real <a> with an href", () =>
+  all([
+    check(
+      renderToString(internal).startsWith("<a"),
+      toBe(true),
+    ),
+    check(
+      renderToString(internal).includes(
+        'href="/docs"',
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("external link opens safely and announces itself", () =>
+  all([
+    check(
+      renderToString(external).includes(
+        'target="_blank"',
+      ),
+      toBe(true),
+    ),
+    check(
+      renderToString(external).includes(
+        'rel="noopener noreferrer"',
+      ),
+      toBe(true),
+    ),
+    check(
+      renderToString(external).includes(
+        "opens in a new tab",
+      ),
+      toBe(true),
+    ),
+    // internal links carry none of the external machinery
+    check(
+      renderToString(internal).includes("target"),
+      toBe(false),
+    ),
+  ]));
+
+test("link is identifiable by more than color (underline)", () =>
+  check(
+    collectCss(internal).includes(
+      "text-decoration:underline",
+    ),
+    toBe(true),
+  ));
+
+test("textLink is pure", () =>
+  check(
+    renderToString(
+      textLink({
+        label: "Docs",
+        to: "/docs",
+        external: false,
+      }),
+    ),
+    toBe(renderToString(internal)),
+  ));

--- a/packages/plggmatic/src/Component/usecase/textLink.ts
+++ b/packages/plggmatic/src/Component/usecase/textLink.ts
@@ -1,0 +1,72 @@
+import { type SoftStr } from "plgg";
+import {
+  type Html,
+  a,
+  text,
+  attr,
+  href,
+} from "plgg-view";
+import {
+  style_,
+  textColor,
+  decl,
+} from "plggmatic/styleEntry";
+import {
+  focusRing,
+  hoverDim,
+} from "plggmatic/Component/model/interaction";
+
+/**
+ * A text link's props. `external` marks a link that
+ * leaves the site, so it opens in a new tab AND is
+ * announced as such (no surprise navigation — a
+ * no-dark-patterns default).
+ */
+export type TextLinkProps = Readonly<{
+  label: SoftStr;
+  to: SoftStr;
+  external: boolean;
+}>;
+
+/**
+ * The navigation component. **Recorded rule**:
+ * navigation is always a real `<a>` carrying an `href`
+ * (never a div-with-onclick), with a standing underline
+ * so a link is identifiable without relying on color
+ * alone; an `external` link opens in a new tab and
+ * announces it (`target=_blank` + `rel=noopener
+ * noreferrer` + a visible `↗` affordance and an extended
+ * accessible label), so the user is never surprised.
+ * Carries the shared focus ring and hover feedback.
+ */
+export const textLink = (
+  props: TextLinkProps,
+): Html<never, "a"> =>
+  a(
+    [
+      href(props.to),
+      ...(props.external
+        ? [
+            attr("target", "_blank"),
+            attr("rel", "noopener noreferrer"),
+            attr(
+              "aria-label",
+              `${props.label} (opens in a new tab)`,
+            ),
+          ]
+        : []),
+      style_(
+        textColor("primary"),
+        decl("text-decoration", "underline"),
+        focusRing,
+        hoverDim,
+      ),
+    ],
+    [
+      text(
+        props.external
+          ? `${props.label} ↗`
+          : props.label,
+      ),
+    ],
+  );

--- a/packages/plggmatic/src/Component/usecase/themeToggle.spec.ts
+++ b/packages/plggmatic/src/Component/usecase/themeToggle.spec.ts
@@ -1,0 +1,82 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  renderToString,
+  collectCss,
+} from "plgg-view";
+import { themeToggle } from "plggmatic/Component/usecase/themeToggle";
+
+const light = themeToggle({
+  scheme: "light",
+  toggle: "toggle",
+});
+const dark = themeToggle({
+  scheme: "dark",
+  toggle: "toggle",
+});
+
+test("themeToggle is a labelled <button>", () =>
+  all([
+    check(
+      renderToString(light).startsWith("<button"),
+      toBe(true),
+    ),
+    check(
+      renderToString(light).includes(
+        'aria-label="Switch to dark mode"',
+      ),
+      toBe(true),
+    ),
+    check(
+      renderToString(dark).includes(
+        'aria-label="Switch to light mode"',
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("shows the current scheme's icon (shape, not color)", () =>
+  all([
+    // light shows the sun (8-ray path), dark the crescent
+    check(
+      renderToString(light).includes(
+        "M12 18a6 6",
+      ),
+      toBe(true),
+    ),
+    check(
+      renderToString(light).includes(
+        "M9.822 2.238",
+      ),
+      toBe(false),
+    ),
+    check(
+      renderToString(dark).includes(
+        "M9.822 2.238",
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("themeToggle carries the shared focus ring", () =>
+  check(
+    collectCss(light).includes(
+      ":focus-visible{outline:2px solid var(--pm-primary)",
+    ),
+    toBe(true),
+  ));
+
+test("themeToggle is pure", () =>
+  check(
+    renderToString(
+      themeToggle({
+        scheme: "light",
+        toggle: "toggle",
+      }),
+    ),
+    toBe(renderToString(light)),
+  ));

--- a/packages/plggmatic/src/Component/usecase/themeToggle.ts
+++ b/packages/plggmatic/src/Component/usecase/themeToggle.ts
@@ -1,0 +1,99 @@
+import { type SoftStr } from "plgg";
+import {
+  type Html,
+  button as buttonEl,
+  svg,
+  path,
+  attr,
+  type_,
+  onClick,
+} from "plgg-view";
+import {
+  type Scheme,
+  style_,
+  bg,
+  textColor,
+  border,
+  rounded,
+  p,
+  pointer,
+} from "plggmatic/styleEntry";
+import {
+  focusRing,
+  hoverDim,
+} from "plggmatic/Component/model/interaction";
+
+// The oracle's sun (8-ray) and crescent-moon paths,
+// single `currentColor` fills, ported from plggpress's
+// navBar so the toggle inherits the control's ink and
+// flips with the theme like text.
+const SUN_D: SoftStr =
+  "M12 18a6 6 0 1 1 0-12 6 6 0 0 1 0 12zM11 1h2v3h-2zm0 19h2v3h-2zM3.515 4.929l1.414-1.414L7.05 5.636 5.636 7.05 3.515 4.93zM16.95 18.364l1.414-1.414 2.121 2.121-1.414 1.414-2.121-2.121zm2.121-14.85l1.414 1.415-2.121 2.121-1.414-1.414 2.121-2.121zM5.636 16.95l1.414 1.414-2.121 2.121-1.414-1.414 2.121-2.121zM23 11v2h-3v-2zM4 11v2H1v-2z";
+const MOON_D: SoftStr =
+  "M9.822 2.238a9 9 0 0 0 11.94 11.94C20.768 18.654 16.775 22 12 22 6.477 22 2 17.523 2 12c0-4.775 3.346-8.768 7.822-9.762z";
+
+const icon = (d: SoftStr): Html<never, "svg"> =>
+  svg(
+    [
+      attr("viewBox", "0 0 24 24"),
+      attr("width", "18"),
+      attr("height", "18"),
+      attr("fill", "currentColor"),
+      attr("aria-hidden", "true"),
+    ],
+    [path([attr("d", d)], [])],
+  );
+
+/**
+ * A theme toggle's props. `scheme` is the CURRENTLY
+ * active scheme (so the button shows where a click will
+ * take you); `toggle` is the `Msg` a click produces.
+ */
+export type ThemeToggleProps<Msg> = Readonly<{
+  scheme: Scheme;
+  toggle: Msg;
+}>;
+
+/**
+ * The appearance-switch component, exercising the token
+ * layer's scheme mechanism. **Recorded rule**: the
+ * framework ships the VIEW ONLY — the toggle renders the
+ * current scheme's icon (sun in light, moon in dark) and
+ * emits a `toggle` `Msg`; applying the `dark` class to
+ * `<html>` (the contract from the token ticket) is the
+ * consuming app's `update`/effect seam, so the component
+ * stays pure. The `aria-label` names the destination
+ * scheme, and the icon is a non-color cue (shape, not
+ * hue) for the current one. Carries the shared focus
+ * ring and hover feedback.
+ */
+export const themeToggle = <Msg>(
+  props: ThemeToggleProps<Msg>,
+): Html<Msg, "button"> =>
+  buttonEl(
+    [
+      type_("button"),
+      attr(
+        "aria-label",
+        props.scheme === "light"
+          ? "Switch to dark mode"
+          : "Switch to light mode",
+      ),
+      onClick(props.toggle),
+      style_(
+        bg("surface"),
+        textColor("text"),
+        border,
+        rounded("full"),
+        p(2),
+        pointer,
+        focusRing,
+        hoverDim,
+      ),
+    ],
+    [
+      props.scheme === "light"
+        ? icon(SUN_D)
+        : icon(MOON_D),
+    ],
+  );

--- a/packages/plggmatic/src/Component/usecase/typography.spec.ts
+++ b/packages/plggmatic/src/Component/usecase/typography.spec.ts
@@ -1,0 +1,88 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  renderToString,
+  collectCss,
+  text,
+  p as para,
+} from "plgg-view";
+import {
+  heading,
+  prose,
+} from "plggmatic/Component/usecase/typography";
+
+test("heading level maps to the real hN element", () =>
+  all([
+    check(
+      renderToString(
+        heading(1, "Title"),
+      ).startsWith("<h1"),
+      toBe(true),
+    ),
+    check(
+      renderToString(
+        heading(2, "Title"),
+      ).startsWith("<h2"),
+      toBe(true),
+    ),
+    check(
+      renderToString(
+        heading(3, "Title"),
+      ).startsWith("<h3"),
+      toBe(true),
+    ),
+    check(
+      renderToString(
+        heading(4, "Title"),
+      ).startsWith("<h4"),
+      toBe(true),
+    ),
+  ]));
+
+test("heading size follows the font-size token scale", () =>
+  all([
+    check(
+      collectCss(heading(1, "T")).includes(
+        "font-size:1.5rem",
+      ),
+      toBe(true),
+    ),
+    check(
+      collectCss(heading(4, "T")).includes(
+        "font-size:1rem",
+      ),
+      toBe(true),
+    ),
+  ]));
+
+test("prose is a container capping the reading measure", () =>
+  all([
+    check(
+      renderToString(
+        prose([para([], [text("body")])]),
+      ).startsWith("<div"),
+      toBe(true),
+    ),
+    check(
+      collectCss(
+        prose([para([], [text("body")])]),
+      ).includes("max-width:48rem"),
+      toBe(true),
+    ),
+  ]));
+
+test("typography is pure", () =>
+  all([
+    check(
+      renderToString(heading(2, "Title")),
+      toBe(renderToString(heading(2, "Title"))),
+    ),
+    check(
+      renderToString(prose([text("x")])),
+      toBe(renderToString(prose([text("x")]))),
+    ),
+  ]));

--- a/packages/plggmatic/src/Component/usecase/typography.ts
+++ b/packages/plggmatic/src/Component/usecase/typography.ts
@@ -1,0 +1,107 @@
+import { type SoftStr } from "plgg";
+import {
+  type Html,
+  type Flow,
+  type Phrasing,
+  type Attribute,
+  h1,
+  h2,
+  h3,
+  h4,
+  div,
+  text,
+} from "plgg-view";
+import {
+  type FontSize,
+  style_,
+  textColor,
+  text as fontSize,
+  weight,
+  maxW,
+} from "plggmatic/styleEntry";
+
+/**
+ * A heading level. A closed union so a level maps to a
+ * real `h1`–`h4` element (and its font token) — an
+ * invalid level cannot be requested.
+ */
+export type HeadingLevel = 1 | 2 | 3 | 4;
+
+// Each level's semantic element builder. A closed switch
+// (no `default`) keeps it exhaustive: a new level is a
+// compile error until it has an element.
+const levelEl = (
+  level: HeadingLevel,
+): (<Msg>(
+  attributes: ReadonlyArray<Attribute<Msg>>,
+  children: ReadonlyArray<Phrasing<Msg>>,
+) => Html<Msg>) => {
+  switch (level) {
+    case 1:
+      return h1;
+    case 2:
+      return h2;
+    case 3:
+      return h3;
+    case 4:
+      return h4;
+  }
+};
+
+// Visual size follows the font-size token scale, largest
+// at the top level. Exhaustive over the level union.
+const LEVEL_SIZE: Record<HeadingLevel, FontSize> =
+  {
+    1: "2xl",
+    2: "xl",
+    3: "lg",
+    4: "base",
+  };
+
+/**
+ * The heading component. **Recorded rule**: the heading
+ * `level` is a semantic prop that maps 1:1 to a real
+ * `h1`–`h4` element, and the visual size is drawn from
+ * the font-size token scale by that same level — so the
+ * document outline and the type scale never drift apart
+ * (no "looks like an h2 but is a div"). Themed `text`
+ * ink.
+ */
+export const heading = (
+  level: HeadingLevel,
+  content: SoftStr,
+): Html<never> =>
+  levelEl(level)(
+    [
+      style_(
+        fontSize(LEVEL_SIZE[level]),
+        weight(600),
+        textColor("text"),
+      ),
+    ],
+    [text(content)],
+  );
+
+/**
+ * The prose component. **Recorded rule**: prose is a
+ * typographic container that establishes the reading
+ * baseline once — themed body ink and a capped readable
+ * measure (48rem, i.e. 192 spacing units) — for
+ * arbitrary flow content; per-element prose rules (link
+ * underline weight, code badges, list rhythm) are added
+ * one at a time as real documents demand them, not
+ * pre-built here (emergent design system).
+ */
+export const prose = <Msg>(
+  body: ReadonlyArray<Flow<Msg>>,
+): Html<Msg, "div"> =>
+  div(
+    [
+      style_(
+        textColor("text"),
+        fontSize("base"),
+        maxW(192),
+      ),
+    ],
+    body,
+  );

--- a/packages/plggmatic/src/Layout/index.ts
+++ b/packages/plggmatic/src/Layout/index.ts
@@ -1,0 +1,26 @@
+/**
+ * The plggmatic Layout module: the column-oriented
+ * pattern as COMPOSITION. A screen is an ordered
+ * {@link row} of {@link column}s, each holding
+ * {@link pane} landmarks — small builders that take
+ * `(parts, children)` like element builders take
+ * `(attributes, children)`. There is no layout config
+ * object and no interpreter: sizing (`basis`/`fluid`),
+ * scroll, and responsiveness are style parts and the
+ * consumer's own stylesheet targeting the `pm-row`/
+ * `pm-col`/`pm-pane` hooks. An explicit named barrel
+ * (house style); it grows one recorded rule at a time.
+ */
+export {
+  type PaneRole,
+  landmarkTag,
+} from "plggmatic/Layout/model/pane";
+export {
+  type Parts,
+  row,
+  column,
+  pane,
+  navPane,
+  mainPane,
+  asidePane,
+} from "plggmatic/Layout/usecase/combinators";

--- a/packages/plggmatic/src/Layout/model/pane.ts
+++ b/packages/plggmatic/src/Layout/model/pane.ts
@@ -1,0 +1,33 @@
+import { type SoftStr } from "plgg";
+
+/**
+ * The landmark role a pane plays in the page. A closed
+ * union (not a free string), mapped to a semantic HTML
+ * element by an exhaustive `Record` — so every pane
+ * renders as a real landmark and a new role cannot be
+ * added without giving it an element. This is the seed
+ * set the known consumers need (a `navigation` sidebar,
+ * a `main` content column, a `complementary` rail/list);
+ * more roles arrive one at a time with a consumer.
+ */
+export type PaneRole =
+  | "navigation"
+  | "main"
+  | "complementary";
+
+/**
+ * The semantic element each {@link PaneRole} renders as.
+ * Exhaustive: a role missing here is a `tsc` error, so
+ * the accessibility skeleton (nav/main/aside landmarks)
+ * can never silently degrade to a bare `div`.
+ */
+const LANDMARK: Record<PaneRole, SoftStr> = {
+  navigation: "nav",
+  main: "main",
+  complementary: "aside",
+};
+
+/** The landmark tag for a role. */
+export const landmarkTag = (
+  role: PaneRole,
+): SoftStr => LANDMARK[role];

--- a/packages/plggmatic/src/Layout/usecase/combinators.spec.ts
+++ b/packages/plggmatic/src/Layout/usecase/combinators.spec.ts
@@ -1,0 +1,126 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  renderToString,
+  collectCss,
+  text,
+} from "plgg-view";
+import {
+  basis,
+  fluid,
+  p,
+} from "plggmatic/styleEntry";
+import {
+  row,
+  column,
+  navPane,
+  mainPane,
+  asidePane,
+} from "plggmatic/Layout/usecase/combinators";
+
+// The compositional pattern in one expression: a fixed
+// nav track, a fluid reading track — geometry composed
+// as atoms, structure as nesting, no config object.
+const strip = row(
+  [],
+  [
+    column(
+      [basis("220px")],
+      [navPane([p(2)], [text("nav")])],
+    ),
+    column(
+      [fluid],
+      [
+        mainPane([p(4)], [text("read")]),
+        asidePane([], [text("meta")]),
+      ],
+    ),
+  ],
+);
+
+const rendered = renderToString(strip);
+const css = collectCss(strip);
+
+test("panes render as real landmarks", () =>
+  all([
+    check(rendered.includes("<nav"), toBe(true)),
+    check(rendered.includes("<main"), toBe(true)),
+    check(
+      rendered.includes("<aside"),
+      toBe(true),
+    ),
+  ]));
+
+test("combinators expose their class hooks", () =>
+  all([
+    check(
+      rendered.includes('class="pm-row'),
+      toBe(true),
+    ),
+    check(
+      rendered.includes('class="pm-col'),
+      toBe(true),
+    ),
+    check(
+      rendered.includes('class="pm-pane'),
+      toBe(true),
+    ),
+  ]));
+
+test("consumer parts merge into the one class list", () =>
+  all([
+    // sizing atoms land as atomic rules...
+    check(
+      css.includes("flex:0 0 220px"),
+      toBe(true),
+    ),
+    check(
+      css.includes("flex:1 1 auto"),
+      toBe(true),
+    ),
+    check(
+      css.includes("min-width:0"),
+      toBe(true),
+    ),
+    // ...and the base flow is still present
+    check(
+      css.includes("display:flex"),
+      toBe(true),
+    ),
+    check(
+      css.includes("flex-direction:column"),
+      toBe(true),
+    ),
+  ]));
+
+test("a custom hook rides the same class list", () => {
+  const hooked = renderToString(
+    column(["ex-reader", fluid], [text("x")]),
+  );
+  return all([
+    check(
+      hooked.includes('class="pm-col'),
+      toBe(true),
+    ),
+    // one class attribute carries hook + atoms — no
+    // second class attr to clobber it
+    check(
+      hooked.includes(" ex-reader"),
+      toBe(true),
+    ),
+    check(
+      hooked.split('class="').length - 1,
+      toBe(1),
+    ),
+  ]);
+});
+
+test("combinators are pure", () =>
+  all([
+    check(renderToString(strip), toBe(rendered)),
+    check(collectCss(strip), toBe(css)),
+  ]));

--- a/packages/plggmatic/src/Layout/usecase/combinators.ts
+++ b/packages/plggmatic/src/Layout/usecase/combinators.ts
@@ -1,0 +1,90 @@
+import { type SoftStr } from "plgg";
+import { type Html, el } from "plgg-view";
+import {
+  type Styles,
+  type Variant,
+  style_,
+  flex,
+  flexCol,
+} from "plggmatic/styleEntry";
+import {
+  type PaneRole,
+  landmarkTag,
+} from "plggmatic/Layout/model/pane";
+
+/**
+ * What a combinator accepts as its style slot: exactly
+ * `style_`'s parts (class hooks, atom groups, variants).
+ * The combinator merges its own base parts and the
+ * consumer's into ONE `style_` call — `style_` is the
+ * sole class authority, so two calls on one element
+ * would clobber each other.
+ */
+export type Parts = ReadonlyArray<
+  SoftStr | Styles | Variant
+>;
+
+/**
+ * The screen as a horizontal strip of columns — the
+ * column-oriented pattern's outermost piece. Purely
+ * compositional: `row` contributes only `display:flex`
+ * and its `pm-row` hook; height, snapping, and collapse
+ * are the consumer's parts and stylesheet. **Recorded
+ * rule**: layout combinators take `(parts, children)`
+ * like element builders take `(attributes, children)` —
+ * options are style atoms you compose, never fields on a
+ * config object.
+ */
+export const row = <Msg>(
+  parts: Parts,
+  children: ReadonlyArray<Html<Msg>>,
+): Html<Msg> =>
+  el(
+    "div",
+    [style_("pm-row", flex, ...parts)],
+    children,
+  );
+
+/**
+ * One vertical track of the row. Contributes only the
+ * column flow (`flex-direction:column`) and its `pm-col`
+ * hook; sizing is a composed atom — `basis("220px")` for
+ * a fixed track, `fluid` for the one that fills the
+ * remaining row.
+ */
+export const column = <Msg>(
+  parts: Parts,
+  children: ReadonlyArray<Html<Msg>>,
+): Html<Msg> =>
+  el(
+    "div",
+    [style_("pm-col", flexCol, ...parts)],
+    children,
+  );
+
+/**
+ * A landmark content region inside a column: the
+ * accessibility skeleton of the pattern. `pane(role)`
+ * renders the role's semantic element (`nav`, `main`,
+ * `aside` — see {@link landmarkTag}) around arbitrary
+ * consumer content, with the `pm-pane` hook. Scroll,
+ * padding, and measure caps are composed parts.
+ */
+export const pane =
+  (role: PaneRole) =>
+  <Msg>(
+    parts: Parts,
+    children: ReadonlyArray<Html<Msg>>,
+  ): Html<Msg> =>
+    el(
+      landmarkTag(role),
+      [style_("pm-pane", ...parts)],
+      children,
+    );
+
+/** The `navigation` pane — renders a `<nav>` landmark. */
+export const navPane = pane("navigation");
+/** The `main` pane — renders the `<main>` landmark. */
+export const mainPane = pane("main");
+/** The `complementary` pane — renders an `<aside>`. */
+export const asidePane = pane("complementary");

--- a/packages/plggmatic/src/Meta/model/identity.spec.ts
+++ b/packages/plggmatic/src/Meta/model/identity.spec.ts
@@ -1,0 +1,24 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  frameworkName,
+  cssPrefix,
+} from "plggmatic/Meta/model/identity";
+
+test("frameworkName is the one word for this framework", () => {
+  return check(frameworkName, toBe("plggmatic"));
+});
+
+test("cssPrefix namespaces plggmatic custom properties", () => {
+  return all([
+    check(cssPrefix, toBe("pm")),
+    check(
+      `--${cssPrefix}-surface`,
+      toBe("--pm-surface"),
+    ),
+  ]);
+});

--- a/packages/plggmatic/src/Meta/model/identity.ts
+++ b/packages/plggmatic/src/Meta/model/identity.ts
@@ -1,0 +1,16 @@
+/**
+ * The framework's fixed identity values. `frameworkName`
+ * is the one word for this framework everywhere (docs,
+ * data attributes, error messages); `cssPrefix` is the
+ * namespace every plggmatic CSS custom property carries
+ * (`--pm-...`), keeping framework variables from
+ * colliding with an app's own.
+ */
+export const frameworkName = "plggmatic";
+
+/**
+ * Prefix for CSS custom properties owned by plggmatic
+ * (e.g. `--pm-surface`). Consumed by the color-scheme
+ * emitter.
+ */
+export const cssPrefix = "pm";

--- a/packages/plggmatic/src/Style/index.ts
+++ b/packages/plggmatic/src/Style/index.ts
@@ -1,0 +1,31 @@
+/**
+ * The plggmatic Style module: the framework's typed
+ * color-scheme seed. An explicit named barrel (house
+ * style) — it grows one recorded token/utility at a time
+ * as components demand them, never as a pre-built
+ * catalog. Surfaced to consumers through the
+ * `plggmatic/style` subpath (see `src/styleEntry.ts`),
+ * where these color atoms shadow plgg-view's literal-hex
+ * ones.
+ */
+export {
+  type Color,
+  colors,
+  colorHex,
+  colorVar,
+} from "plggmatic/Style/model/token";
+export {
+  type Scheme,
+  schemes,
+} from "plggmatic/Style/model/scheme";
+export {
+  bg,
+  color,
+  textColor,
+  border,
+  borderColor,
+  outline,
+  basis,
+  fluid,
+} from "plggmatic/Style/usecase/utilities";
+export { schemeCss } from "plggmatic/Style/usecase/schemeCss";

--- a/packages/plggmatic/src/Style/model/scheme.ts
+++ b/packages/plggmatic/src/Style/model/scheme.ts
@@ -1,0 +1,25 @@
+/**
+ * The two color schemes plggmatic ships. A closed union
+ * (not a free string) so the scheme emitter and any
+ * future scheme-aware code are exhaustive: adding a
+ * third scheme is a compile error everywhere it must be
+ * handled, never a silent gap.
+ *
+ * Light is the default; dark is opted into by a single
+ * `dark` class on `<html>`, which reswitches every
+ * `--pm-*` custom property (see the scheme CSS emitter).
+ * The scheme is chosen by one class, not threaded
+ * through the component tree — colors stay data.
+ */
+export type Scheme = "light" | "dark";
+
+/**
+ * Every {@link Scheme}, in emit order (light first, then
+ * the `html.dark` override). Iterated by the scheme CSS
+ * emitter and by the contrast spec so both cover the
+ * whole union without hard-coding the members twice.
+ */
+export const schemes: ReadonlyArray<Scheme> = [
+  "light",
+  "dark",
+];

--- a/packages/plggmatic/src/Style/model/token.spec.ts
+++ b/packages/plggmatic/src/Style/model/token.spec.ts
@@ -1,0 +1,64 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  type Color,
+  colors,
+  colorHex,
+  colorVar,
+} from "plggmatic/Style/model/token";
+import { schemes } from "plggmatic/Style/model/scheme";
+
+// A #rrggbb literal — the shape every palette value
+// must take so the scheme emitter produces valid CSS.
+const isHex = (v: string): boolean =>
+  /^#[0-9a-f]{6}$/.test(v);
+
+test("every color has a hex in every scheme", () =>
+  all(
+    schemes.flatMap((scheme) =>
+      colors.map((c) =>
+        check(
+          isHex(colorHex(scheme, c)),
+          toBe(true),
+        ),
+      ),
+    ),
+  ));
+
+// A compile-time exhaustiveness pin: every `Color` must
+// be a key here, so a role added to the union but not to
+// the palette (or vice versa) fails `tsc` before any test
+// runs. The runtime check confirms `colors` reaches all
+// of them with no duplicates.
+const SEEN: Record<Color, true> = {
+  surface: true,
+  "surface-2": true,
+  primary: true,
+  "primary-text": true,
+  text: true,
+  muted: true,
+  border: true,
+  danger: true,
+};
+
+test("colors lists exactly the Color union once", () =>
+  all([
+    check(
+      colors.length,
+      toBe(new Set(colors).size),
+    ),
+    check(
+      colors.every((c) => SEEN[c]),
+      toBe(true),
+    ),
+  ]));
+
+test("colorVar references the --pm namespace", () =>
+  check(
+    colorVar("surface"),
+    toBe("var(--pm-surface)"),
+  ));

--- a/packages/plggmatic/src/Style/model/token.ts
+++ b/packages/plggmatic/src/Style/model/token.ts
@@ -1,0 +1,126 @@
+import { type SoftStr } from "plgg";
+import { type Scheme } from "plggmatic/Style/model/scheme";
+import { cssPrefix } from "plggmatic/Meta/model/identity";
+
+/**
+ * The closed color-role vocabulary. Because it is a
+ * union (not a free string) an unknown role like
+ * `bg("blurple")` is a compile error — the type-driven
+ * win over stringly CSS classes. This is a deliberate
+ * *seed*, not a catalog (emergent-design-system): each
+ * role earns its place from a concrete consumer in the
+ * pane (20260703144035) and component (20260703144036)
+ * tickets, and later roles arrive one-per-component.
+ *
+ * Roles and their consumers:
+ * - `surface` — the page/pane background prose sits on
+ * - `surface-2` — a secondary panel (code block, table
+ *   header, sunken rail) distinct from `surface`
+ * - `primary` — the accent fill (primary button, active
+ *   marker)
+ * - `primary-text` — the label that sits ON `primary`
+ * - `text` — default body/heading ink on `surface`
+ * - `muted` — secondary ink (captions, metadata); still
+ *   meets AA on both surfaces (not decoration-only)
+ * - `border` — hairline dividers and pane edges
+ * - `danger` — error text and destructive affordances
+ */
+export type Color =
+  | "surface"
+  | "surface-2"
+  | "primary"
+  | "primary-text"
+  | "text"
+  | "muted"
+  | "border"
+  | "danger";
+
+/**
+ * Every {@link Color}, for specs and the scheme emitter
+ * to iterate without re-listing the union. Kept in sync
+ * with {@link Color} by the exhaustiveness spec: a role
+ * added to the union but missing here (or vice versa) is
+ * caught there.
+ */
+export const colors: ReadonlyArray<Color> = [
+  "surface",
+  "surface-2",
+  "primary",
+  "primary-text",
+  "text",
+  "muted",
+  "border",
+  "danger",
+];
+
+/**
+ * The concrete hex for every role in every scheme. The
+ * `Record<Scheme, Record<Color, SoftStr>>` shape makes
+ * this exhaustive twice over: a missing scheme or a
+ * missing role is a `tsc` error, so the palette can
+ * never ship a hole. Literal color values live ONLY
+ * here — every atom resolves through {@link colorVar}
+ * (a `var(--pm-*)` reference), so this map is the single
+ * place a scheme's values are defined and the scheme CSS
+ * emitter's only source.
+ *
+ * Values are a warm editorial palette (ink on cream in
+ * light, warm off-white on near-black in dark), adopted
+ * from the plgg-view seed and tuned so every text/surface
+ * pairing clears WCAG 2.2 AA (see the contrast spec):
+ * - `muted` is darker than plgg-view's decorative gray so
+ *   secondary text meets 4.5:1 on `surface-2`, not just
+ *   the 3:1 large-text floor.
+ * - the `primary`/`primary-text` button pair is held
+ *   constant across schemes (a stable brand affordance),
+ *   so its 6:1 label contrast holds in both.
+ * - dark `danger` is lightened to a coral so error text
+ *   stays legible on the near-black surfaces.
+ */
+const PALETTE: Record<
+  Scheme,
+  Record<Color, SoftStr>
+> = {
+  light: {
+    surface: "#fffdf7",
+    "surface-2": "#f0e9d8",
+    primary: "#1f6b54",
+    "primary-text": "#fbfaf3",
+    text: "#2a241d",
+    muted: "#6b6459",
+    border: "#e6dcc8",
+    danger: "#b23a2a",
+  },
+  dark: {
+    surface: "#1c1a17",
+    "surface-2": "#262320",
+    primary: "#1f6b54",
+    "primary-text": "#fbfaf3",
+    text: "#ece7dd",
+    muted: "#a39a8a",
+    border: "#38332b",
+    danger: "#ec8175",
+  },
+};
+
+/**
+ * A role's literal hex in a given scheme. Consumed by
+ * the scheme CSS emitter and the contrast spec; runtime
+ * code and atoms use {@link colorVar} instead so a single
+ * `dark` class reswitches everything.
+ */
+export const colorHex = (
+  scheme: Scheme,
+  c: Color,
+): SoftStr => PALETTE[scheme][c];
+
+/**
+ * The `var(--pm-<role>)` reference for a role — what
+ * every color atom emits, so the value is resolved by
+ * the active scheme's custom properties at paint time
+ * rather than baked in. The `pm` namespace comes from
+ * {@link cssPrefix}, keeping framework variables from
+ * colliding with an app's own.
+ */
+export const colorVar = (c: Color): SoftStr =>
+  `var(--${cssPrefix}-${c})`;

--- a/packages/plggmatic/src/Style/usecase/contrast.spec.ts
+++ b/packages/plggmatic/src/Style/usecase/contrast.spec.ts
@@ -1,0 +1,76 @@
+import {
+  test,
+  check,
+  all,
+  toBeGreaterThanOrEqual,
+} from "plgg-test";
+import {
+  type Color,
+  colorHex,
+} from "plggmatic/Style/model/token";
+import { schemes } from "plggmatic/Style/model/scheme";
+
+// The accessibility gate, computed — not asserted by
+// eye. Every foreground text role must clear WCAG 2.2 AA
+// normal-text contrast (>= 4.5:1) against every surface
+// it is used on, in BOTH schemes, or this spec fails and
+// the ticket cannot be approved. The math is the WCAG
+// 2.x relative-luminance / contrast-ratio formula.
+
+const channel = (b: number): number => {
+  const s = b / 255;
+  return s <= 0.03928
+    ? s / 12.92
+    : Math.pow((s + 0.055) / 1.055, 2.4);
+};
+
+const luminance = (hex: string): number => {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return (
+    0.2126 * channel(r) +
+    0.7152 * channel(g) +
+    0.0722 * channel(b)
+  );
+};
+
+const contrast = (
+  fg: string,
+  bg: string,
+): number => {
+  const a = luminance(fg) + 0.05;
+  const b = luminance(bg) + 0.05;
+  return a > b ? a / b : b / a;
+};
+
+// Each meaningful foreground/background pairing the seed
+// promises. `[text-role, surface-role]`.
+const PAIRS: ReadonlyArray<
+  readonly [Color, Color]
+> = [
+  ["text", "surface"],
+  ["text", "surface-2"],
+  ["muted", "surface"],
+  ["muted", "surface-2"],
+  ["danger", "surface"],
+  ["danger", "surface-2"],
+  ["primary-text", "primary"],
+];
+
+const AA_NORMAL = 4.5;
+
+test("every text/surface pair clears WCAG AA", () =>
+  all(
+    schemes.flatMap((scheme) =>
+      PAIRS.map(([fg, bg]) =>
+        check(
+          contrast(
+            colorHex(scheme, fg),
+            colorHex(scheme, bg),
+          ),
+          toBeGreaterThanOrEqual(AA_NORMAL),
+        ),
+      ),
+    ),
+  ));

--- a/packages/plggmatic/src/Style/usecase/schemeCss.ts
+++ b/packages/plggmatic/src/Style/usecase/schemeCss.ts
@@ -1,0 +1,36 @@
+import { type SoftStr } from "plgg";
+import { type Scheme } from "plggmatic/Style/model/scheme";
+import {
+  colors,
+  colorHex,
+} from "plggmatic/Style/model/token";
+import { cssPrefix } from "plggmatic/Meta/model/identity";
+
+/**
+ * The `--pm-*` custom-property declarations for one
+ * scheme, as a single CSS body (`--pm-surface:#…;…`).
+ * Every role is emitted, in {@link colors} order.
+ */
+const varsFor = (scheme: Scheme): SoftStr =>
+  colors
+    .map(
+      (c) =>
+        `--${cssPrefix}-${c}:${colorHex(scheme, c)};`,
+    )
+    .join("");
+
+/**
+ * The framework's base color stylesheet: the light
+ * scheme on `:root` and the dark override under
+ * `html.dark`, toggled by one `dark` class. This is the
+ * ONLY CSS this token layer owns — layout, typography,
+ * and the `@media` responsiveness the atomic utilities
+ * cannot express belong to the pane-system ticket
+ * (20260703144035), which appends its base CSS after
+ * this block. Inject this into the document `<style>`
+ * ahead of the collected atomic rules so the custom
+ * properties are defined before any `var(--pm-*)`
+ * resolves. Escape-safe (no `<`, `>`, `&`), so it
+ * survives an SSR text escaper byte-for-byte.
+ */
+export const schemeCss: SoftStr = `:root{${varsFor("light")}}html.dark{${varsFor("dark")}}`;

--- a/packages/plggmatic/src/Style/usecase/utilities.spec.ts
+++ b/packages/plggmatic/src/Style/usecase/utilities.spec.ts
@@ -1,0 +1,96 @@
+import {
+  test,
+  check,
+  all,
+  toEqual,
+} from "plgg-test";
+import {
+  bg,
+  color,
+  textColor,
+  border,
+  borderColor,
+  outline,
+  basis,
+  fluid,
+} from "plggmatic/Style/usecase/utilities";
+
+test("color atoms resolve through --pm-* vars", () =>
+  all([
+    check(
+      bg("surface"),
+      toEqual([
+        {
+          prop: "background-color",
+          value: "var(--pm-surface)",
+        },
+      ]),
+    ),
+    check(
+      color("text"),
+      toEqual([
+        {
+          prop: "color",
+          value: "var(--pm-text)",
+        },
+      ]),
+    ),
+    check(
+      textColor("muted"),
+      toEqual([
+        {
+          prop: "color",
+          value: "var(--pm-muted)",
+        },
+      ]),
+    ),
+    check(
+      borderColor("primary"),
+      toEqual([
+        {
+          prop: "border-color",
+          value: "var(--pm-primary)",
+        },
+      ]),
+    ),
+    check(
+      outline("primary"),
+      toEqual([
+        {
+          prop: "outline",
+          value: "2px solid var(--pm-primary)",
+        },
+      ]),
+    ),
+  ]));
+
+test("border is a three-atom hairline in the var", () =>
+  check(
+    border,
+    toEqual([
+      { prop: "border-width", value: "1px" },
+      { prop: "border-style", value: "solid" },
+      {
+        prop: "border-color",
+        value: "var(--pm-border)",
+      },
+    ]),
+  ));
+
+test("column tracks are whole-shorthand atoms", () =>
+  all([
+    check(
+      basis("220px"),
+      toEqual([
+        { prop: "flex", value: "0 0 220px" },
+        { prop: "width", value: "220px" },
+      ]),
+    ),
+    check(
+      fluid,
+      toEqual([
+        { prop: "flex", value: "1 1 auto" },
+        { prop: "min-width", value: "0" },
+      ]),
+    ),
+  ]));

--- a/packages/plggmatic/src/Style/usecase/utilities.ts
+++ b/packages/plggmatic/src/Style/usecase/utilities.ts
@@ -1,0 +1,89 @@
+import { type SoftStr } from "plgg";
+import {
+  type Styles,
+  decl,
+} from "plgg-view/style";
+import {
+  type Color,
+  colorVar,
+} from "plggmatic/Style/model/token";
+
+/**
+ * plggmatic's color atoms. They mirror plgg-view's
+ * `bg`/`color`/`border` utilities but resolve every color
+ * through a `var(--pm-*)` custom property instead of a
+ * literal hex, so one `dark` class on `<html>` reswitches
+ * the scheme without re-styling a single element. Each
+ * returns plgg-view `Styles` (pure `{prop, value}` data),
+ * so they compose through `style_` exactly like the
+ * built-in utilities — plggmatic adds theming, not a new
+ * styling engine. These SHADOW the same-named plgg-view
+ * utilities on the `plggmatic/style` subpath; reach for
+ * these to get scheme-aware color.
+ */
+
+/** Background fill from a themed color role. */
+export const bg = (c: Color): Styles =>
+  decl("background-color", colorVar(c));
+
+/** Text (foreground) color from a themed role. */
+export const color = (c: Color): Styles =>
+  decl("color", colorVar(c));
+
+/**
+ * Text color — the explicit spelling for the common
+ * case, distinct from plgg-view's `color` so intent
+ * reads at the call site. Same atom as {@link color}.
+ */
+export const textColor = color;
+
+/**
+ * A hairline border in the themed `border` role. Emitted
+ * as three atoms (width/style/color) rather than a
+ * `border` shorthand so the color stays a `var(--pm-*)`
+ * reference the scheme can reswitch.
+ */
+export const border: Styles = [
+  ...decl("border-width", "1px"),
+  ...decl("border-style", "solid"),
+  ...decl("border-color", colorVar("border")),
+];
+
+/** Border color from a themed role. */
+export const borderColor = (c: Color): Styles =>
+  decl("border-color", colorVar(c));
+
+/**
+ * A 2px focus outline in a themed role — the visible,
+ * non-color-dependent focus affordance components pair
+ * with `:focus-visible` (accessibility-first: focus is
+ * never conveyed by color alone at the component layer).
+ */
+export const outline = (c: Color): Styles =>
+  decl("outline", `2px solid ${colorVar(c)}`);
+
+/**
+ * A fixed column track: the whole flex shorthand plus
+ * the width, so a `basis` column neither grows nor
+ * shrinks off its measure. One atom (not separate
+ * grow/shrink longhands) so it can never half-conflict
+ * with {@link fluid} through class order. Introduced
+ * with the layout combinators: sizing is a composed
+ * atom, not a config field.
+ */
+export const basis = (w: SoftStr): Styles => [
+  ...decl("flex", `0 0 ${w}`),
+  ...decl("width", w),
+];
+
+/**
+ * The fluid column track: fills the remaining row and
+ * may shrink below its content (`min-width:0`, so long
+ * words cannot blow the strip open). The counterpart of
+ * {@link basis}; a row is expected to hold at most one —
+ * a composition convention, not a type constraint.
+ */
+export const fluid: Styles = [
+  ...decl("flex", "1 1 auto"),
+  ...decl("min-width", "0"),
+];

--- a/packages/plggmatic/src/index.ts
+++ b/packages/plggmatic/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * plggmatic — a column-oriented UI design framework on
+ * the plgg family. The root barrel is an explicit
+ * named-export list; it grows as the framework does
+ * (tokens, pane alignment, components). Style utilities
+ * live on the `plggmatic/style` subpath so their
+ * Tailwind-style names (`p`, `text`, …) never collide
+ * with Html element builders here.
+ */
+export {
+  frameworkName,
+  cssPrefix,
+} from "plggmatic/Meta/model/identity";
+export {
+  type PaneRole,
+  type Parts,
+  landmarkTag,
+  row,
+  column,
+  pane,
+  navPane,
+  mainPane,
+  asidePane,
+} from "plggmatic/Layout";
+export {
+  type InteractionState,
+  type ButtonProps,
+  type TextLinkProps,
+  type HeadingLevel,
+  type ThemeToggleProps,
+  type NavItem,
+  focusRing,
+  hoverDim,
+  pressDim,
+  button,
+  textLink,
+  heading,
+  prose,
+  themeToggle,
+  navTree,
+} from "plggmatic/Component";

--- a/packages/plggmatic/src/styleEntry.ts
+++ b/packages/plggmatic/src/styleEntry.ts
@@ -1,0 +1,38 @@
+/**
+ * The `plggmatic/style` subpath: the framework's style
+ * vocabulary. It starts as plgg-view's inline-style
+ * utilities and token maps, and plggmatic's own tokens
+ * (color scheme, spacing, pane geometry) extend it in
+ * place — consumers import the whole vocabulary from
+ * this one entry. Kept off the root barrel because
+ * utility names (`p`, `text`, …) collide with Html
+ * element builders.
+ *
+ * plggmatic's themed color atoms (`bg`, `color`,
+ * `textColor`, `border`, `borderColor`, `outline`) and
+ * its `Color`/`Scheme` types are re-exported AFTER the
+ * plgg-view star, so they SHADOW plgg-view's same-named
+ * literal-hex utilities: importing `bg` from
+ * `plggmatic/style` yields the `var(--pm-*)`,
+ * scheme-aware version. Everything else (layout,
+ * spacing, sizing, radius, font-size, `style_`) is
+ * plgg-view's, unchanged.
+ */
+export * from "plgg-view/style";
+export {
+  type Color,
+  type Scheme,
+  colors,
+  schemes,
+  colorHex,
+  colorVar,
+  bg,
+  color,
+  textColor,
+  border,
+  borderColor,
+  outline,
+  basis,
+  fluid,
+  schemeCss,
+} from "plggmatic/Style";

--- a/packages/plggmatic/tsconfig.json
+++ b/packages/plggmatic/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    /* Compiler Option */
+    "target": "ES2021",
+    /* This package is `"type": "module"` and its source is
+       run directly via Node type-stripping (plgg-test), so
+       it uses ESNext + Bundler resolution: extensionless
+       self-alias specifiers (`plggmatic/...`) resolve while
+       modules stay ESM. */
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "paths": {
+      "plggmatic/*": [
+        "./src/*"
+      ]
+    },
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"],
+    /* Type Checking Rules */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "forceConsistentCasingInFileNames": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowJs": false,
+    "erasableSyntaxOnly": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/plggpress/package-lock.json
+++ b/packages/plggpress/package-lock.json
@@ -195,7 +195,7 @@
       "license": "MIT"
     },
     "../plgg-http": {
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg"
@@ -300,7 +300,7 @@
       "license": "MIT"
     },
     "../plgg-server": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "plgg": "file:../plgg",
@@ -360,7 +360,7 @@
       "license": "MIT"
     },
     "../plgg-test": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/site/.gitignore
+++ b/packages/site/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/site/.prettierrc.json
+++ b/packages/site/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 50,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSameLine": false
+}

--- a/packages/site/README.md
+++ b/packages/site/README.md
@@ -1,0 +1,11 @@
+# @plggmatic/site
+
+> **UNSTABLE** - Experimental study work. Part of the [plgg monorepo](../../README.md).
+
+The **documentation site for [plggmatic](../plggmatic/)** — the column-oriented
+UI design framework — built with [plggpress](../plggpress/). Every code fence on
+a page has a compile-checked twin under `examples/` (type-checked against the
+shipped `plggmatic` package), and the build runs plggpress's build-time
+dead-link checker over every page. The workbench demo
+([`packages/plggmatic-example/`](../plggmatic-example/)) is nested under the
+served site at `/example/`. Private `@plggmatic/site`, not published.

--- a/packages/site/bundle.config.ts
+++ b/packages/site/bundle.config.ts
@@ -1,0 +1,38 @@
+// Dev-server config for `plgg-bundle dev` (the toolchain
+// serves the site in development; the static build still
+// runs through `plggpress build`). The `dev` section wires
+// the site's Fetch entry, the watched roots (site content
+// + plggpress theme SOURCE in the sibling plgg checkout),
+// the tunnel host allowlist, and the cross-package
+// `sourceAliases` that make `plggpress/*` resolve to
+// source so theme edits hot-reload. The non-`dev` fields
+// are the bundler's required shape; dev never builds, so
+// `entries` is empty.
+export default {
+  root: import.meta.dirname,
+  rootDir: ".",
+  outDir: "dist",
+  fileNamePattern: "[name].[format].js",
+  entries: [],
+  formats: ["es"],
+  alias: { prefix: "site", srcRoot: "." },
+  dev: {
+    entry: "devEntry.ts",
+    port: 5182,
+    watch: [
+      ".",
+      "../../../plgg/packages/plggpress/src",
+    ],
+    allowedHosts: [
+      "localhost",
+      "plggmatic-guide.qmu.dev",
+    ],
+    sourceAliases: [
+      {
+        prefix: "plggpress",
+        srcDir:
+          "../../../plgg/packages/plggpress/src",
+      },
+    ],
+  },
+};

--- a/packages/site/color-scheme.md
+++ b/packages/site/color-scheme.md
@@ -1,0 +1,64 @@
+# Color scheme
+
+plggmatic's color is a closed, typed vocabulary of **roles**, not a free palette. Eight roles cover the seed set's needs; each has a value in both the light and dark **schemes**. An unknown role is a compile error, and every text/surface pairing is checked against WCAG 2.2 AA contrast by a test that computes the ratio — the palette cannot ship a failing pair.
+
+## The eight roles
+
+The current default is a warm editorial palette — ink on cream paper with a pine accent — tuned so every text/surface pairing clears AA. Literal values live in exactly one place (the palette map); everything else references them by role.
+
+| Role | Job | Light | Dark |
+| --- | --- | --- | --- |
+| `surface` | page / pane background | `#fffdf7` | `#1c1a17` |
+| `surface-2` | secondary panel — code, table header, sunken rail | `#f0e9d8` | `#262320` |
+| `primary` | accent fill — buttons, active markers | `#1f6b54` | `#1f6b54` |
+| `primary-text` | label that sits on `primary` | `#fbfaf3` | `#fbfaf3` |
+| `text` | body & heading ink | `#2a241d` | `#ece7dd` |
+| `muted` | secondary ink — captions, metadata | `#6b6459` | `#a39a8a` |
+| `border` | hairline dividers & pane edges | `#e6dcc8` | `#38332b` |
+| `danger` | error text & destructive affordances | `#b23a2a` | `#ec8175` |
+
+The `primary` / `primary-text` button pair is held constant across schemes — a stable brand affordance whose label contrast holds in both.
+
+## Custom properties, one `dark` class
+
+The recorded decision behind the scheme: color atoms resolve to `var(--pm-*)` custom properties rather than literal hex, so a single `dark` class on `<html>` reschemes the entire tree without re-styling any element. `schemeCss` emits the values as `:root{…}` plus a `html.dark{…}` override.
+
+```ts
+import {
+  bg,
+  textColor,
+  border,
+  p,
+  rounded,
+  style_,
+  schemeCss,
+} from "plggmatic/style";
+import { div, text } from "plgg-view";
+
+const card = div(
+  [style_(bg("surface"), textColor("text"), border, p(4), rounded("md"))],
+  [text("A themed surface")],
+);
+
+// `:root{--pm-surface:…}html.dark{--pm-surface:…}` —
+// inject once into the document <style>.
+const baseColorCss = schemeCss;
+```
+
+`bg`, `textColor`, and `border` from `plggmatic/style` are the themed atoms — they emit `var(--pm-*)` and shadow plgg-view's literal-hex utilities of the same name. The spacing and radius utilities (`p`, `rounded`) come straight from plgg-view.
+
+## Contrast is a gate, not a guideline
+
+Every text role is checked on every surface it sits on, in both schemes, against the WCAG 2.2 AA floor for normal text (4.5:1). A spec computes each ratio; a value that dips below the floor fails the build. These are the measured ratios of the current palette:
+
+| Pairing | Light | Dark |
+| --- | --- | --- |
+| `text` on `surface` | 15.09:1 | 14.09:1 |
+| `text` on `surface-2` | 12.68:1 | 12.68:1 |
+| `muted` on `surface` | 5.75:1 | 6.24:1 |
+| `muted` on `surface-2` | 4.83:1 | 5.62:1 |
+| `danger` on `surface` | 5.85:1 | 6.58:1 |
+| `danger` on `surface-2` | 4.91:1 | 5.93:1 |
+| `primary-text` on `primary` | 6.10:1 | 6.10:1 |
+
+`muted` is deliberately darker than a decorative gray so secondary text clears the floor on both surfaces — not just the 3:1 large-text allowance — and dark-mode `danger` is lightened to a coral for the same reason. The tightest pairing (`muted` on `surface-2` at 4.83:1) still passes; because the gate is computed, tuning a value that would break it is caught before it ships.

--- a/packages/site/components/button.md
+++ b/packages/site/components/button.md
@@ -1,0 +1,28 @@
+# Button
+
+`button` is the action component: a pure function returning a real `<button type="button">`. It is never a `div` with a click handler.
+
+## Recorded rule
+
+An action is a real `<button>`, and `disabled` is conveyed by **more than color** — the native `disabled` attribute (which also drops it from the tab order), a `cursor:not-allowed`, and reduced opacity, with the hover and press feedback withheld. Enabled buttons carry the shared focus ring (a 2px outline offset from the control — a geometric, not color-only, focus cue).
+
+## Usage
+
+`onPress` is the typed `Msg` a click produces; the component holds no state.
+
+```ts
+import { button } from "plggmatic";
+import { renderToString } from "plgg-view";
+
+type Msg = { readonly kind: "save" };
+
+const saveButton = button<Msg>({
+  label: "Save",
+  onPress: { kind: "save" },
+  disabled: false,
+});
+
+const markup = renderToString(saveButton);
+```
+
+Pass `disabled: true` to render the native disabled state; the click no longer produces a `Msg`.

--- a/packages/site/components/nav-tree.md
+++ b/packages/site/components/nav-tree.md
@@ -1,0 +1,31 @@
+# Nav tree
+
+`navTree` is the recursive, config-driven navigation tree — the docs sidebar you are reading is this shape.
+
+## Recorded rule
+
+`navTree` emits **list markup only** — a `<ul>` of `<li>`, nested for children — and does not wrap itself in a `<nav>` landmark. The landmark is owned by the [pane alignment](/pane-alignment) system's `navigation` pane it sits inside, so the two never produce nested or duplicate nav landmarks (the higher-level pane policy wins). The leaf whose `href` equals the active path is marked `aria-current="page"` at build time; a header node with no link renders as plain text. Zero client JavaScript.
+
+## Usage
+
+`href` is an `Option`: `some` is a link, `none` is a group header.
+
+```ts
+import { navTree, type NavItem } from "plggmatic";
+import { some, none } from "plgg";
+
+const items: ReadonlyArray<NavItem> = [
+  {
+    label: "Guide",
+    href: none(),
+    children: [
+      { label: "Getting started", href: some("/getting-started"), children: [] },
+      { label: "Color scheme", href: some("/color-scheme"), children: [] },
+    ],
+  },
+];
+
+const tree = navTree(items, "/getting-started");
+```
+
+Place the returned tree in a `navigation` pane's `body`, and the pane supplies the `<nav>` landmark around it.

--- a/packages/site/components/text-link.md
+++ b/packages/site/components/text-link.md
@@ -1,0 +1,27 @@
+# Text link
+
+`textLink` is the navigation component: a real `<a>` carrying an `href`.
+
+## Recorded rule
+
+Navigation is always a real `<a>` with an `href`, with a standing underline so a link is identifiable without relying on color alone. An `external` link opens in a new tab **and** announces it — `target="_blank"`, `rel="noopener noreferrer"`, a visible `↗` affordance, and an extended accessible label — so the user is never surprised (a no-dark-patterns default). It carries the shared focus ring and hover feedback.
+
+## Usage
+
+```ts
+import { textLink } from "plggmatic";
+
+const repoLink = textLink({
+  label: "plggmatic on GitHub",
+  to: "https://github.com/qmu/plggmatic",
+  external: true,
+});
+
+const docsLink = textLink({
+  label: "Getting started",
+  to: "/getting-started",
+  external: false,
+});
+```
+
+An internal link carries none of the external machinery — no `target`, no new-tab announcement.

--- a/packages/site/components/theme-toggle.md
+++ b/packages/site/components/theme-toggle.md
@@ -1,0 +1,27 @@
+# Theme toggle
+
+`themeToggle` is the appearance switch — the component that exercises the [color scheme](/color-scheme)'s light/dark mechanism.
+
+## Recorded rule
+
+The framework ships the **view only**. The toggle renders the current scheme's icon (a sun in light, a crescent in dark — a shape cue, not a color one) and emits a `toggle` `Msg`; applying the `dark` class to `<html>` is the consuming app's update/effect seam, so the component stays pure. The `aria-label` names the destination scheme, and the control carries the shared focus ring.
+
+## Usage
+
+Pass the current `scheme` (the button shows where a click will take you) and the `Msg` a click produces:
+
+```ts
+import { themeToggle } from "plggmatic";
+import { type Scheme } from "plggmatic/style";
+
+type Msg = { readonly kind: "toggleScheme" };
+
+const current: Scheme = "light";
+
+const toggle = themeToggle<Msg>({
+  scheme: current,
+  toggle: { kind: "toggleScheme" },
+});
+```
+
+Your `update` handles the `toggleScheme` `Msg` by flipping the scheme and toggling the `dark` class — the one side effect the framework leaves to the app.

--- a/packages/site/components/typography.md
+++ b/packages/site/components/typography.md
@@ -1,0 +1,24 @@
+# Typography
+
+Two components carry the type system: `heading` and `prose`.
+
+## Recorded rule
+
+The heading `level` is a semantic prop that maps 1:1 to a real `h1`–`h4` element, and its visual size is drawn from the font-size token scale by that same level — so the document outline and the type scale never drift apart. There is no "looks like an h2 but is a div."
+
+`prose` is a typographic container that establishes the reading baseline once: themed body ink and a capped readable measure (48rem). Per-element prose rules (link underline weight, code badges, list rhythm) are added one at a time as real documents demand them, not pre-built.
+
+## Usage
+
+```ts
+import { heading, prose } from "plggmatic";
+import { p, text } from "plgg-view";
+
+const title = heading(1, "Color scheme");
+
+const body = prose([
+  p([], [text("Tokens resolve through custom properties.")]),
+]);
+```
+
+`heading` accepts levels `1` through `4`; an out-of-range level is a compile error.

--- a/packages/site/devEntry.ts
+++ b/packages/site/devEntry.ts
@@ -1,0 +1,19 @@
+import { join } from "node:path";
+import { pressDevEntry } from "plggpress/devEntry";
+
+// The site's dev entry for `plgg-bundle dev`: bind
+// plggpress's render factory to this site's content root,
+// `site.config.ts`, and deploy base. plgg-bundle re-imports
+// this module on every watched edit — and because
+// `plggpress/*` resolves to plggpress's SOURCE here (see
+// bundle.config.ts `dev.sourceAliases`), a theme `.ts` edit
+// re-evaluates and a content edit re-discovers, so both
+// hot-reload in the browser with no restart.
+export default pressDevEntry({
+  contentDir: import.meta.dirname,
+  configPath: join(
+    import.meta.dirname,
+    "site.config.ts",
+  ),
+  base: process.env.DOCS_BASE ?? "/",
+});

--- a/packages/site/examples/button.ts
+++ b/packages/site/examples/button.ts
@@ -1,0 +1,15 @@
+// Twin of the Button page's code fence. `onPress` is the
+// typed `Msg` a click produces — the component is a pure
+// view with no internal state.
+import { button } from "plggmatic";
+import { renderToString } from "plgg-view";
+
+type Msg = { readonly kind: "save" };
+
+export const saveButton = button<Msg>({
+  label: "Save",
+  onPress: { kind: "save" },
+  disabled: false,
+});
+
+export const markup = renderToString(saveButton);

--- a/packages/site/examples/colorScheme.ts
+++ b/packages/site/examples/colorScheme.ts
@@ -1,0 +1,32 @@
+// Twin of the Color scheme page's code fence. Themed
+// color atoms resolve through `var(--pm-*)` custom
+// properties, so one `dark` class on `<html>` reschemes
+// the whole tree; `schemeCss` is the custom-property
+// block that defines them.
+import {
+  bg,
+  textColor,
+  border,
+  p,
+  rounded,
+  style_,
+  schemeCss,
+} from "plggmatic/style";
+import { div, text } from "plgg-view";
+
+export const card = div(
+  [
+    style_(
+      bg("surface"),
+      textColor("text"),
+      border,
+      p(4),
+      rounded("md"),
+    ),
+  ],
+  [text("A themed surface")],
+);
+
+// `:root{--pm-surface:…}html.dark{--pm-surface:…}` —
+// inject once into the document <style>.
+export const baseColorCss = schemeCss;

--- a/packages/site/examples/navTree.ts
+++ b/packages/site/examples/navTree.ts
@@ -1,0 +1,30 @@
+// Twin of the Nav tree page's code fence. `href` is an
+// `Option`: `some` is a link, `none` is a plain group
+// header. The item whose href equals the active path is
+// marked `aria-current` at build time.
+import { navTree, type NavItem } from "plggmatic";
+import { some, none } from "plgg";
+
+const items: ReadonlyArray<NavItem> = [
+  {
+    label: "Guide",
+    href: none(),
+    children: [
+      {
+        label: "Getting started",
+        href: some("/getting-started"),
+        children: [],
+      },
+      {
+        label: "Color scheme",
+        href: some("/color-scheme"),
+        children: [],
+      },
+    ],
+  },
+];
+
+export const tree = navTree(
+  items,
+  "/getting-started",
+);

--- a/packages/site/examples/shell.ts
+++ b/packages/site/examples/shell.ts
@@ -1,0 +1,31 @@
+// Twin of the Pane alignment page's code fence: the
+// compositional layout — builders + atoms, no config.
+import {
+  row,
+  column,
+  navPane,
+  mainPane,
+} from "plggmatic";
+import { basis, fluid, p } from "plggmatic/style";
+import {
+  renderToString,
+  collectCss,
+  text,
+} from "plgg-view";
+
+const screen = row(
+  [],
+  [
+    column(
+      [basis("220px")],
+      [navPane([p(2)], [text("nav")])],
+    ),
+    column(
+      [fluid],
+      [mainPane([p(4)], [text("reading")])],
+    ),
+  ],
+);
+
+export const html = renderToString(screen);
+export const css = collectCss(screen);

--- a/packages/site/examples/textLink.ts
+++ b/packages/site/examples/textLink.ts
@@ -1,0 +1,16 @@
+// Twin of the Text link page's code fence. An `external`
+// link opens in a new tab and announces it — a
+// no-surprise default.
+import { textLink } from "plggmatic";
+
+export const repoLink = textLink({
+  label: "plggmatic on GitHub",
+  to: "https://github.com/qmu/plggmatic",
+  external: true,
+});
+
+export const docsLink = textLink({
+  label: "Getting started",
+  to: "/getting-started",
+  external: false,
+});

--- a/packages/site/examples/themeToggle.ts
+++ b/packages/site/examples/themeToggle.ts
@@ -1,0 +1,15 @@
+// Twin of the Theme toggle page's code fence. The
+// component ships the view only: it renders the CURRENT
+// scheme's icon and emits a `toggle` Msg — applying the
+// `dark` class to <html> is the app's update/effect seam.
+import { themeToggle } from "plggmatic";
+import { type Scheme } from "plggmatic/style";
+
+type Msg = { readonly kind: "toggleScheme" };
+
+const current: Scheme = "light";
+
+export const toggle = themeToggle<Msg>({
+  scheme: current,
+  toggle: { kind: "toggleScheme" },
+});

--- a/packages/site/examples/typography.ts
+++ b/packages/site/examples/typography.ts
@@ -1,0 +1,18 @@
+// Twin of the Typography page's code fence. `heading`
+// maps a semantic level to a real `h1`–`h4`; `prose` is
+// the reading container.
+import { heading, prose } from "plggmatic";
+import { p, text } from "plgg-view";
+
+export const title = heading(1, "Color scheme");
+
+export const body = prose([
+  p(
+    [],
+    [
+      text(
+        "Tokens resolve through custom properties.",
+      ),
+    ],
+  ),
+]);

--- a/packages/site/examples/workbench.ts
+++ b/packages/site/examples/workbench.ts
@@ -1,0 +1,18 @@
+// Twin of the workbench page's code fence: the column
+// stack is derived per render, the geometry composed.
+import { row, column } from "plggmatic";
+import { basis } from "plggmatic/style";
+import { type Html } from "plgg-view";
+
+declare const sectionsPanes: ReadonlyArray<
+  Html<never>
+>;
+declare const pushed: ReadonlyArray<Html<never>>;
+
+export const stack = row(
+  [],
+  [
+    column([basis("220px")], sectionsPanes),
+    ...pushed,
+  ],
+);

--- a/packages/site/getting-started.md
+++ b/packages/site/getting-started.md
@@ -1,0 +1,47 @@
+# Getting started
+
+plggmatic ships as one package, `plggmatic`, with two entry points: the root barrel for `Html`-returning builders (layout and components) and the `plggmatic/style` subpath for the token utilities.
+
+## Install
+
+```bash
+npm install plggmatic
+```
+
+plggmatic depends on the plgg family (`plgg`, `plgg-view`). Inside this monorepo those are resolved through `file:` links to each package's built `dist`; in your own project they install as normal dependencies.
+
+## The two entry points
+
+- `plggmatic` — the root barrel: the layout builders (`row`, `column`, `pane`/`navPane`/`mainPane`/`asidePane`) and the fundamental components (`button`, `textLink`, `heading`, `prose`, `themeToggle`, `navTree`).
+- `plggmatic/style` — the token vocabulary: themed color utilities (`bg`, `textColor`, `border`, …) plus the plgg-view style utilities (`p`, `text`, `flex`, …) and the `schemeCss` custom-property block.
+
+Style utilities live on their own subpath because their short names (`p`, `text`) would collide with the `Html` element builders on the root barrel.
+
+## A first screen
+
+A screen is composed, not configured: an ordered `row` of `column`s holding landmark `pane`s, with sizing as composed style atoms. Render it with plgg-view's `renderToString`; its atomic styles ride along and `collectCss` gathers them:
+
+```ts
+import { row, column, navPane, mainPane } from "plggmatic";
+import { basis, fluid, p } from "plggmatic/style";
+import { renderToString, collectCss, text } from "plgg-view";
+
+const screen = row(
+  [],
+  [
+    column(
+      [basis("220px")],
+      [navPane([p(2)], [text("nav")])],
+    ),
+    column(
+      [fluid],
+      [mainPane([p(4)], [text("reading")])],
+    ),
+  ],
+);
+
+const html = renderToString(screen);
+const css = collectCss(screen);
+```
+
+See [Pane alignment](/pane-alignment) for the builders and hooks, and the [color scheme](/color-scheme) page for the `--pm-*` block you concatenate ahead of the collected CSS.

--- a/packages/site/index.md
+++ b/packages/site/index.md
@@ -1,0 +1,17 @@
+# plggmatic — a column-oriented UI design framework
+
+plggmatic is a UI design framework built on the [plgg](https://github.com/qmu/plgg) family. It gives you three things as typed, composable data: a **column-oriented pane alignment system**, a **light/dark color scheme** driven by design tokens, and a small set of **fundamental components** that are pure functions returning plgg-view `Html`.
+
+Start with [Getting started](/getting-started), read about the [color scheme](/color-scheme) and [pane alignment](/pane-alignment), or browse the [components](/components/button).
+
+## Not the same as the old plggmatic
+
+There was a previous `plggmatic` package inside the plgg monorepo — an internal re-export shim of plgg-view's builders. This framework reuses that name deliberately, but it is a different thing: a design framework layered on plgg-view, not a re-export. Where this documentation says "plggmatic," it means the framework described here.
+
+## Column, Pane, Alignment, Token, Scheme
+
+The framework holds to one word per concept. A screen is a row of **Columns**; each column stacks **Panes** (landmark content regions); their sizing and collapse is the **Alignment** system. Color, spacing, and type are **Tokens**; the light and dark sets of token values are **Schemes**. The same vocabulary is used across every page here and in the source.
+
+## Built on plgg-view, styled by tokens
+
+Components return plgg-view `Html<Msg>` and are styled only through the token utilities, so color reschemes with a single `dark` class on `<html>` and nothing renders state by color alone. Everything is server-rendered from pure data — there is no framework runtime to boot.

--- a/packages/site/package-lock.json
+++ b/packages/site/package-lock.json
@@ -1,0 +1,209 @@
+{
+  "name": "@plggmatic/site",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@plggmatic/site",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "plggmatic": "file:../plggmatic",
+        "plggpress": "file:../plggpress"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg": "file:../plgg",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-view": "file:../plgg-view",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plgg": {
+      "version": "0.0.27",
+      "extraneous": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plgg-bundle": {
+      "version": "0.0.2",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-bundle": "bin/plgg-bundle.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-test": "file:../plgg-test"
+      }
+    },
+    "../../../plgg/packages/plgg-view": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../../../plgg/packages/plggpress": {
+      "version": "0.0.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "plggmatic": "file:../plggmatic"
+      },
+      "bin": {
+        "plggpress": "bin/plggpress.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plgg": {
+      "version": "0.0.27",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plgg-bundle": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^6.0.3"
+      },
+      "bin": {
+        "plgg-bundle": "bin/plgg-bundle.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-test": "file:../plgg-test"
+      }
+    },
+    "../plgg-view": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plggmatic": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "plgg-view": "file:../plgg-view"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../plggpress": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "plgg": "file:../plgg",
+        "plgg-cli": "file:../plgg-cli",
+        "plgg-highlight": "file:../plgg-highlight",
+        "plgg-http": "file:../plgg-http",
+        "plgg-md": "file:../plgg-md",
+        "plgg-server": "file:../plgg-server",
+        "plgg-view": "file:../plgg-view"
+      },
+      "bin": {
+        "plggpress": "bin/plggpress.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "plgg-bundle": "file:../plgg-bundle",
+        "plgg-test": "file:../plgg-test",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/plgg": {
+      "resolved": "../plgg",
+      "link": true
+    },
+    "node_modules/plgg-bundle": {
+      "resolved": "../plgg-bundle",
+      "link": true
+    },
+    "node_modules/plgg-view": {
+      "resolved": "../plgg-view",
+      "link": true
+    },
+    "node_modules/plggmatic": {
+      "resolved": "../plggmatic",
+      "link": true
+    },
+    "node_modules/plggpress": {
+      "resolved": "../plggpress",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@plggmatic/site",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "The documentation site for plggmatic — the column-oriented UI design framework. Built with plggpress; every code example compiles against the shipped plggmatic package.",
+  "scripts": {
+    "dev": "plgg-bundle dev bundle.config.ts",
+    "build": "plggpress build --config site.config.ts --contentDir . --outDir dist",
+    "examples": "tsc --noEmit -p tsconfig.examples.json",
+    "check": "npm run examples && npm run build",
+    "preview": "python3 -m http.server --directory dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qmu/plggmatic.git"
+  },
+  "author": "qmu",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/qmu/plggmatic/issues"
+  },
+  "homepage": "https://github.com/qmu/plggmatic#readme",
+  "dependencies": {
+    "plggmatic": "file:../plggmatic",
+    "plggpress": "file:../plggpress"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "plgg": "file:../plgg",
+    "plgg-bundle": "file:../plgg-bundle",
+    "plgg-view": "file:../plgg-view",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/site/pane-alignment.md
+++ b/packages/site/pane-alignment.md
@@ -1,0 +1,46 @@
+# Pane alignment
+
+plggmatic models a screen as an ordered **row** of vertical **Columns**, each holding **Panes** — landmark content regions (`nav`, `main`, `aside`). The alignment system is **compositional**: three small builders (`row`, `column`, `pane`) that take `(parts, children)` exactly like element builders take `(attributes, children)`. There is no layout config object and no interpreter — sizing, scroll, and responsiveness are style parts you compose and stylesheet rules you own.
+
+## The pieces
+
+- **`row(parts, columns)`** — the screen as a horizontal strip. Contributes `display:flex` and the `pm-row` hook, nothing else.
+- **`column(parts, panes)`** — one vertical track. Contributes the column flow and the `pm-col` hook; its width is a composed atom: `basis("220px")` for a fixed track, `fluid` for the one that fills the remaining row.
+- **`pane(role)(parts, children)`** — a landmark region: `navigation` → `<nav>`, `main` → `<main>`, `complementary` → `<aside>` (also pre-bound as `navPane`, `mainPane`, `asidePane`). The accessibility skeleton is in the composition itself.
+
+Options become atoms, structure becomes nesting:
+
+```ts
+import { row, column, navPane, mainPane } from "plggmatic";
+import { basis, fluid, p, style_ } from "plggmatic/style";
+import { renderToString, collectCss, text } from "plgg-view";
+
+const screen = row(
+  [],
+  [
+    column(
+      [basis("220px")],
+      [navPane([p(2)], [text("nav")])],
+    ),
+    column(
+      [fluid],
+      [mainPane([p(4)], [text("reading")])],
+    ),
+  ],
+);
+
+const html = renderToString(screen);
+const css = collectCss(screen);
+```
+
+The composed atoms travel **with** the elements — `collectCss` gathers them into content-hashed atomic rules, the same channel every other plggmatic style utility uses. No second stylesheet layer to assemble.
+
+## Hooks, not options
+
+Each builder exposes a stable class hook (`pm-row`, `pm-col`, `pm-pane`), and any string part you pass joins the same class list (`column(["reader", fluid], …)`). What atoms cannot express — `@media` collapse, per-column viewport scroll, snap strips — you write in your own stylesheet against those hooks. The framework does not guess your breakpoints.
+
+Because `style_` is the **sole class authority**, builders merge their base parts and yours into one call; never attach a separate `class` attribute next to style parts — pass the hook as a string part instead.
+
+## Ownership split with the color scheme
+
+The [color scheme](/color-scheme) layer owns the `--pm-*` custom-property block; the composed atoms and your hook-targeting rules reference `var(--pm-*)`, so every column and pane reschemes with one `dark` class. Concatenate the scheme block, your own rules, and the body's collected atomic CSS into one `<style>`.

--- a/packages/site/site.config.ts
+++ b/packages/site/site.config.ts
@@ -1,0 +1,114 @@
+// plggmatic's documentation-site information
+// architecture: pure data validated through plggpress's
+// `defineSite` boundary caster (the one place untrusted
+// config crosses into the typed core). plggpress owns the
+// `SiteConfig` type and the validator; this file supplies
+// only plggmatic's values, cloned from the plgg guide's
+// shape.
+import {
+  defineSite,
+  type SidebarItemInput,
+} from "plggpress";
+
+// GitHub Pages serves a project site under `/<repo>/`; the
+// deploy workflow sets DOCS_BASE so links resolve there,
+// while local dev/preview stay at root. plggpress's href
+// resolver is the single rewrite point downstream.
+const base = process.env.DOCS_BASE ?? "/";
+
+// A sidebar node as authored here: every node carries an
+// explicit `items` array (leaf case `[]`) so it validates
+// against plggpress's `SidebarItemInput`.
+const leaf = (
+  text: string,
+  link: string,
+): SidebarItemInput => ({
+  text,
+  link,
+  items: [],
+});
+
+// One leaf per shipped fundamental component (each has its
+// own documented page with a compiling example).
+const COMPONENTS: ReadonlyArray<
+  readonly [string, string]
+> = [
+  ["Button", "/components/button"],
+  ["Text link", "/components/text-link"],
+  ["Typography", "/components/typography"],
+  ["Theme toggle", "/components/theme-toggle"],
+  ["Nav tree", "/components/nav-tree"],
+];
+
+const config = {
+  base,
+  title: "plggmatic",
+  description:
+    "plggmatic — a column-oriented UI design " +
+    "framework on the plgg family: pane alignment, " +
+    "a typed light/dark color scheme, and " +
+    "fundamental components as pure functions " +
+    "returning plgg-view Html.",
+  nav: [
+    leaf("Guide", "/getting-started"),
+    leaf("Components", "/components/button"),
+    leaf(
+      "GitHub",
+      "https://github.com/qmu/plggmatic",
+    ),
+  ],
+  sidebar: [
+    {
+      text: "Guide",
+      items: [
+        leaf("What is plggmatic?", "/"),
+        leaf(
+          "Getting started",
+          "/getting-started",
+        ),
+        leaf(
+          "Example: the workbench",
+          "/workbench",
+        ),
+      ],
+    },
+    {
+      text: "Foundations",
+      items: [
+        leaf("Color scheme", "/color-scheme"),
+        leaf("Pane alignment", "/pane-alignment"),
+      ],
+    },
+    {
+      text: "Components",
+      items: COMPONENTS.map(([t, l]) =>
+        leaf(t, l),
+      ),
+    },
+  ],
+  social: [
+    {
+      icon: "github",
+      link: "https://github.com/qmu/plggmatic",
+    },
+  ],
+  // The extra Host headers plggpress's node:http dev
+  // server accepts: localhost for local work, the qmu.dev
+  // tunnel host for remote preview.
+  dev: {
+    allowedHosts: [
+      "localhost",
+      "plggmatic-guide.qmu.dev",
+    ],
+  },
+};
+
+// Author-time validation through the boundary caster: an
+// Ok is the typed `SiteConfig`, an Err names the offending
+// field. Exported so a check / plggpress can assert it.
+export const site = defineSite(config);
+
+// The raw config DATA is the default export plggpress's
+// `loadConfig` reads and validates through `defineSite` at
+// build/dev time.
+export default config;

--- a/packages/site/tsconfig.examples.json
+++ b/packages/site/tsconfig.examples.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"],
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["examples/**/*.ts"]
+}

--- a/packages/site/workbench.md
+++ b/packages/site/workbench.md
@@ -1,0 +1,37 @@
+# Example: the workbench
+
+The repository ships a reference app, `@plggmatic/example` — an independent client-side program that displays the **traversable** reading of column-oriented layout: a *column stack*. Where this documentation site runs a fixed sidebar / content / rail arrangement, the workbench **pushes columns as you drill in**: the root column lists sections; selecting a section pushes a notes-list column; selecting a note pushes a reading column. Each pushed column carries sticky header chrome with a close link, a breadcrumb trail in the top bar mirrors the stack, and the whole arrangement round-trips through the URL. Both UIs are compositions of the same `row`/`column`/`pane` builders — the proof that the layout system is a pattern, not a fixed theme.
+
+The built app is served beside this site at the `/example/` path, and its source lives in [`packages/example` on GitHub](https://github.com/qmu/plggmatic/tree/main/packages/plggmatic-example).
+
+## The stack is derived, the geometry is composed
+
+The row's column list is computed from the selection depth on every render — the root column is always present, the deeper columns exist only while their selection does, and each column's sizing is a composed atom:
+
+```ts
+import { row, column } from "plggmatic";
+import { basis } from "plggmatic/style";
+import { type Html } from "plgg-view";
+
+declare const sectionsPanes: ReadonlyArray<Html<never>>;
+declare const pushed: ReadonlyArray<Html<never>>;
+
+const stack = row(
+  [],
+  [
+    column([basis("220px")], sectionsPanes),
+    ...pushed,
+  ],
+);
+```
+
+Fixed tracks keep their measure (`basis("220px")`, `basis("300px")`); the reader composes `fluid` plus its own `"ex-reader"` hook for the app's below-breakpoint rules — options are atoms and hooks, not config fields.
+
+## What the app demonstrates
+
+- **Columns as navigation state** — the stack depth (root → +list → +reader) is derived from one immutable Model (`section` and `note` are `Option`s); pushing and truncating are re-renders, not view mutations.
+- **The URL is the serialized stack** — `toUrl` projects the depth into `` (root), `?s=…`, or `?s=…&n=…`; a deep link reproduces the exact stack, browser back exactly reverses each push, and every close link (`×` in a column header, or a breadcrumb crumb) is a plain `<a>` to the truncating URL — leaving is the same gesture as entering.
+- **Link-driven, runtime-wired** — the plgg-view `application` runtime intercepts in-app clicks and turns them into messages; the app wires no handlers to links at all.
+- **Column identity by key** — the list column is keyed by section and the reader by note, so switching selection remounts the column fresh (scroll reset + entrance fade) instead of patching stale state in place.
+- **The scheme contract, honored purely** — the `--pm-*` variable sets are regenerated from `colorHex` under two app-root classes and the class swaps by re-render; the theme toggle changes the Model and no code mutates the document.
+- **One active-state rule** — a single stylesheet rule paints the inverted pill on anything marked `aria-current="page"`, so the nav tree and the note list share the same selection affordance.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,4 +58,17 @@ cd $REPO_ROOT/packages/plgg-test && npm run build
 # plgg + plgg-view + plgg-router (+ plgg-server's view types) and inlines them
 # from source via the in-house bundler's app target.
 cd $REPO_ROOT/packages/example && npm run build
+# --- plggmatic UI design framework, its docs site, and workbench example ---
+# plggmatic (UI design framework: tokens, row/column/pane combinators,
+# components) — consumes plgg + plgg-view, both built above.
+cd $REPO_ROOT/packages/plggmatic && npm run build
+# plggmatic-example: the workbench CSR app; the app bundler inlines
+# plgg/plgg-view/plggmatic from source, so it builds after plggmatic.
+cd $REPO_ROOT/packages/plggmatic-example && npm run build
+# site: the plggpress-built docs for plggmatic; needs plggpress + plggmatic.
+cd $REPO_ROOT/packages/site && npm run build
+# nest the workbench app under the served docs at /example/.
+rm -rf $REPO_ROOT/packages/site/dist/example
+mkdir -p $REPO_ROOT/packages/site/dist/example
+cp -r $REPO_ROOT/packages/plggmatic-example/dist/. $REPO_ROOT/packages/site/dist/example/
 echo "\n=== All shell scripts have been executed successfully ==="

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -42,3 +42,6 @@ REPO_ROOT=$(git rev-parse --show-toplevel) && cd $REPO_ROOT
 ./scripts/test-plgg-db-migration.sh
 ./scripts/test-plgg-auth.sh
 ./scripts/test-example.sh
+./scripts/test-plggmatic.sh
+./scripts/test-plggmatic-example.sh
+./scripts/test-site.sh

--- a/scripts/npm-install.sh
+++ b/scripts/npm-install.sh
@@ -24,4 +24,7 @@ cd $REPO_ROOT/packages/plgg-db-migration && npm install
 cd $REPO_ROOT/packages/plgg-auth && npm install
 cd $REPO_ROOT/packages/example && npm install
 cd $REPO_ROOT/packages/guide && npm install
+cd $REPO_ROOT/packages/plggmatic && npm install
+cd $REPO_ROOT/packages/plggmatic-example && npm install
+cd $REPO_ROOT/packages/site && npm install
 echo "\n=== All shell scripts have been executed successfully ==="

--- a/scripts/test-plggmatic-example.sh
+++ b/scripts/test-plggmatic-example.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eu
+REPO_ROOT=$(git rev-parse --show-toplevel) && cd $REPO_ROOT
+echo "=== Running 'npm run test' in packages/plggmatic-example ==="
+cd $REPO_ROOT/packages/plggmatic-example && npm run test
+echo "\n=== All shell scripts have been executed successfully ==="

--- a/scripts/test-plggmatic.sh
+++ b/scripts/test-plggmatic.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eu
+REPO_ROOT=$(git rev-parse --show-toplevel) && cd $REPO_ROOT
+echo "=== Running 'npm run test' in packages/plggmatic ==="
+cd $REPO_ROOT/packages/plggmatic && npm run test
+echo "\n=== All shell scripts have been executed successfully ==="

--- a/scripts/test-site.sh
+++ b/scripts/test-site.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eu
+REPO_ROOT=$(git rev-parse --show-toplevel) && cd $REPO_ROOT
+echo "=== Running 'npm run examples' in packages/site ==="
+cd $REPO_ROOT/packages/site && npm run examples
+echo "\n=== All shell scripts have been executed successfully ==="


### PR DESCRIPTION
Brings the **plggmatic UI design framework**, its docs site, and its workbench
demo — developed in the standalone `qmu/plggmatic` repo (to be archived) — into
this monorepo.

This repo already **freed the name**: a prior change (#55) absorbed the former
app-framework `plggmatic` into **plggpress** and deleted the package. So the UI
framework drops in cleanly under the `plggmatic` name — **no rename, and
plggpress is untouched** (it stays self-contained on its absorbed framework).

## New packages

- **`packages/plggmatic`** — the column-oriented UI design framework: a typed
  light/dark color scheme (`var(--pm-*)`), `row`/`column`/`pane` layout
  combinators composed like element builders, components as pure
  `(props) => Html<Msg>`. Distinct from the app-framework surface plggpress
  absorbed.
- **`packages/site`** — its plggpress-built docs (every code fence has a
  compile-checked twin; dead-link checked). Private `@plggmatic/site`.
- **`packages/plggmatic-example`** — the workbench: a traversable column-stack
  (Miller columns) demo, served under the docs at `/example/`. (Named to avoid
  the existing `packages/example`.)

## Other

- `file:` deps use monorepo-sibling paths; the app bundler discovers real
  siblings (no symlink hack).
- Wired into `build.sh` / `check-all.sh` / `npm-install.sh` in dependency order;
  README index + per-package backlinks (gate-readme passes).
- Separate commit: a **plgg-view** fix to render SVG via `createElementNS`
  (plain `createElement` made `svg`/`path` inert) — the workbench's icons need it.

## Verification

`scripts/check-all.sh` green on current `main`: README/vite/happy-dom gates,
full dependency-order build, all package tests — **plggpress 110**
(self-contained), **plggmatic 34**, **plggmatic-example 11**, site doc-fence
type-check clean, plgg-auth 217. Served the built docs and confirmed the
workbench renders (dark scheme, SVG icon drawn) at `/example/`.

Once merged, `qmu/plggmatic` will be archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
