### PR TITLE
Fix plgg-bundle loader hook resolving a directory (EISDIR), with regression test

### DIFF
--- a/.workaholic/release-notes/index.md
+++ b/.workaholic/release-notes/index.md
@@ -14,3 +14,5 @@
 * [Deploy Guide builds plggmatic before plggpress; guide served at plgg.qmu.co.jp](work-20260703-020116.md)
 * [Reduce GitHub Actions to local CI/CD policy minimum: two thin workflow callers, script-driven releases etc](work-20260703-050355.md)
 * [Harden the guide dev container, absorb plggmatic into plggpress, and lead Vocabulary docs with examples](work-20260703-184443.md)
+* [plgg-auth: a from-scratch OpenID Connect identity provider on plgg](work-20260703-220007.md)
+* [Fix plgg-bundle's loader hook resolving a directory (EISDIR) and guard it with a regression test](work-20260704-104625.md)

--- a/.workaholic/release-notes/work-20260704-104625.md
+++ b/.workaholic/release-notes/work-20260704-104625.md
@@ -1,0 +1,26 @@
+# Fix plgg-bundle's loader hook resolving a directory (EISDIR) and guard it with a regression test
+
+## Summary
+
+Fixes the latent twin of a bug PR #55 already fixed in production: the plgg-bundle ESM loader hook resolved a bare-directory self-alias (`plgg-bundle/<dir>`) to the directory itself, which Node reads as a module and crashes with `EISDIR`. Resolution now matches files only (a directory falls through to its `index.ts`), the two near-verbatim hook copies are re-synced, and a typed regression test locks it in.
+
+## Key Changes
+
+- `plgg-bundle/bin/hook.mjs` resolves a bare-directory self-alias to `<dir>/index.ts` instead of the directory, preventing an `EISDIR` crash on load
+- Re-synced the plgg-bundle and plggpress hook copies (plggpress's was fixed in PR #55)
+- Added a typed regression spec — `bin/hook.d.mts` types the `.mjs` loader so a strict `.ts` test can drive `resolve()` with no escape hatch
+
+## Changes
+
+### Fixed
+
+- `plgg-bundle/bin/hook.mjs` `pick()` now matches files only (`statSync(c).isFile()`), so `plgg-bundle/<dir>` lands on `<dir>/index.ts` rather than the directory — no more `EISDIR: illegal operation on a directory` when a bare-directory self-alias is imported
+
+### Added
+
+- `plgg-bundle/bin/hook.d.mts` — hand-written types for the loader hook's `resolve`, so a strict `.ts` spec can import the plain-`.mjs` hook under `allowJs:false` without `any`
+- A plgg-bundle regression spec (`Dev/usecase/selfAliasResolve.spec.ts` + an `aliasDir` fixture) asserting a bare-directory self-alias resolves to its `index.ts`, a file self-alias still resolves to the file, and a non-match falls through — proven red on the old `pick`, green on the fix
+
+## Metrics
+
+- **Tickets Completed**: 1

--- a/.workaholic/stories/work-20260704-104625.md
+++ b/.workaholic/stories/work-20260704-104625.md
@@ -1,0 +1,57 @@
+---
+branch: work-20260704-104625
+tickets_completed: 1
+---
+
+## 1. Overview
+
+A one-ticket follow-up to PR #55: fix the latent twin of a bug that PR #55 already fixed in production. The plgg-bundle ESM loader hook (`bin/hook.mjs`) resolved a bare-directory self-alias to the directory itself — which Node then `read`s as a module and throws `EISDIR`. The fix makes resolution match files only (a directory falls through to its `index.ts`), re-syncs the two near-verbatim hook copies, and adds a typed regression test.
+
+**Highlights:**
+
+1. `plgg-bundle/bin/hook.mjs` `pick()` matches files only, so `plgg-bundle/<dir>` resolves to `<dir>/index.ts` instead of the directory (EISDIR guard).
+2. The two near-verbatim hook copies (plgg-bundle + plggpress) are back in sync — plggpress's was fixed live in PR #55 (`4c3341b`); this closes the un-fixed original.
+3. A typed regression spec proves it — red on the old `pick`, green on the fix — despite the hook being a plain `.mjs` under `allowJs:false`.
+
+## 2. Motivation
+
+PR #55 absorbed plggmatic into plggpress, which introduced the first bare-directory self-alias (`plggpress/framework`) and thereby surfaced this hook bug as an `EISDIR` crash of the guide's static deploy build. That was fixed in plggpress's copy of the hook. The plgg-bundle original — the copy every package builds through — carried the identical `pick()` and was left unfixed: latent only because no plgg-bundle consumer bare-imports a directory *yet*. Fixing it now removes a trap for the next such import and restores the "near-verbatim copy" invariant the two hook files are meant to hold. This is implementation-pillar hygiene: make a machine-checkable guard out of a failure that was previously invisible until runtime.
+
+## 3. Changes
+
+```mermaid
+flowchart LR
+  a1[PR #55: plggpress/framework bare-dir import] --> a2[EISDIR surfaced in plggpress hook]
+  a2 --> a3[Fixed plggpress/bin/hook.mjs]
+  a3 --> a4[plgg-bundle/bin/hook.mjs: same pick, unfixed]
+  a4 --> b1[pick matches files only]
+  b1 --> b2[re-sync the two hook copies]
+  b2 --> b3[typed regression: hook.d.mts + fixture + spec]
+  b3 --> b4[red-on-old / green-on-fix]
+```
+
+The `pick` helper gained an `isFile` guard (`existsSync(c) && statSync(c).isFile()`) so the raw `base` candidate matches only real files; a directory now resolves to `base/index.ts`. Because the hook must stay plain `.mjs` (it runs as Node's resolver before any type-stripping) and the package sets `allowJs:false` with `.spec.ts`-only discovery, the test needed a hand-written `bin/hook.d.mts` to type `resolve` without an escape hatch, a coverage-excluded `aliasDir/` fixture, and a spec driving `resolve()` directly.
+
+## 4. Outcome
+
+The ticket is implemented, verified, and archived; the todo queue is empty.
+
+- Regression proven **red-on-old** (buggy `pick` → the directory test fails) and **green-on-fix**.
+- The two hook copies' `pick`/`isFile` bodies are now **identical**.
+- plgg-bundle: **83 tests pass**, coverage **99.8 / 94.3 / 98.8 / 99.8%** (all >90%).
+- Fresh **`check-all.sh` green** across every package (plgg-bundle, plgg, plggpress, plgg-auth 217, …).
+
+## 5. Historical Analysis
+
+Directly continuous with PR #55 (`work-20260703-184443`), which introduced the first bare-directory self-alias and fixed the plggpress copy of the hook (`4c3341b`). The hook itself dates to the plgg-bundle dev-server/self-alias work; the "near-verbatim copy" split into plggpress's bin was made when plggpress gained its own CLI. This ticket reunifies the two after their PR-#55 divergence.
+
+## 6. Concerns
+
+- **No new deferred concerns.** Pure bug fix plus a regression guard; the common file-resolution path is unchanged and explicitly covered by a no-regression test.
+- Standing note (not introduced here): the two hook files remain hand-maintained copies. If they drift again, extracting a single shared module is the durable fix — out of scope for this bugfix, worth a ticket only if the duplication recurs.
+
+## 7. Successful Development Patterns
+
+- **Chase the twin.** A production fix in one copy immediately motivated auditing its near-verbatim sibling, closing a latent crash before it could surface.
+- **Make the invisible machine-checkable.** The bug was a runtime `EISDIR` with no test; the fix ships with a red/green regression that would have caught it, and re-establishes the copies-in-sync invariant as a verifiable condition.
+- **Type the seam honestly.** Rather than reach for an escape hatch to test an untyped `.mjs` loader under `allowJs:false`, a hand-written `.d.mts` kept the test strict and `any`-free.

--- a/.workaholic/tickets/archive/work-20260704-104625/20260704104836-plgg-bundle-hook-dir-resolution.md
+++ b/.workaholic/tickets/archive/work-20260704-104625/20260704104836-plgg-bundle-hook-dir-resolution.md
@@ -4,6 +4,7 @@ author: a@qmu.jp
 type: bugfix
 layer: [Config]
 effort: 0.5h
+commit_hash: 281341a
 category: Changed
 ---
 

--- a/.workaholic/tickets/todo/a-qmu-jp/20260704104836-plgg-bundle-hook-dir-resolution.md
+++ b/.workaholic/tickets/todo/a-qmu-jp/20260704104836-plgg-bundle-hook-dir-resolution.md
@@ -1,0 +1,99 @@
+---
+created_at: 2026-07-04T10:48:36+09:00
+author: a@qmu.jp
+type: bugfix
+layer: [Config]
+effort: 0.5h
+category: Changed
+---
+
+# `plgg-bundle/bin/hook.mjs`: resolve a bare-directory self-alias to its `index.ts`, not the directory (EISDIR)
+
+## Overview
+
+The plgg-bundle ESM resolver hook rewrites `plgg-bundle/<sub>` self-alias
+specifiers to on-disk `src/<sub>` files via `pick`:
+
+```js
+const pick = (base) => {
+  const candidates = [base, `${base}.ts`, join(base, "index.ts")];
+  return candidates.find((c) => existsSync(c));
+};
+```
+
+`candidates` lists the raw `base` **first**, and `existsSync` is true for a
+**directory**. So a bare-directory self-alias (`plgg-bundle/<dir>`) resolves to
+the directory itself; Node then `read`s it as a module and throws
+`EISDIR: illegal operation on a directory`. The correct resolution is the
+directory's `index.ts`.
+
+This is the **same bug**, in the **same `pick`**, that broke the guide's static
+build (`npx plggpress build` → EISDIR) in PR #55 — fixed there for the
+near-verbatim copy `packages/plggpress/bin/hook.mjs` (commit `4c3341b`) by
+matching **files only**. The two hook files are maintained as near-verbatim
+copies (see the header comment in each), but the plgg-bundle original was left
+unfixed and has now **drifted** from the corrected plggpress copy.
+
+It is currently **latent** for plgg-bundle: no package plgg-bundle resolves
+today imports a *bare directory* self-alias (all existing `plgg-bundle/<sub>`
+imports point at files, whose raw `base` `existsSync` is false so they fall
+through to `base.ts`). The first bare-directory self-import would crash the dev
+server / build — exactly how it surfaced for plggpress once `plggpress/framework`
+(a directory) was introduced. Fix it now, before it bites, and re-sync the two
+copies.
+
+## Key Files
+
+- `packages/plgg-bundle/bin/hook.mjs` — apply the files-only `pick` fix.
+- `packages/plggpress/bin/hook.mjs` — the already-fixed reference (commit
+  `4c3341b`); the two `pick`/`isFile` bodies should match verbatim afterward.
+- A plgg-bundle spec (new) — the regression test (see Quality Gate).
+
+## Implementation Steps
+
+1. In `packages/plgg-bundle/bin/hook.mjs`, mirror the plggpress fix: import
+   `statSync`, add `const isFile = (c) => existsSync(c) && statSync(c).isFile();`,
+   and change `pick` to `candidates.find(isFile)`. Add the same explanatory
+   comment plggpress's copy carries (a directory falls through to its
+   `index.ts`). Leave the rest of the hook untouched.
+2. Confirm the two hook files' `pick`/`isFile` logic is now identical
+   (`diff` the relevant region) so the "near-verbatim copy" invariant holds.
+3. Add a regression test that drives the hook's exported `resolve()` with a
+   **bare-directory** self-alias specifier and asserts it resolves to that
+   directory's `index.ts` (not the directory). Use an existing `src/<dir>` that
+   has an `index.ts`, or add a minimal test fixture directory under `src/` with
+   an `index.ts`; pass a stub `nextResolve`/`context` since the alias branch
+   short-circuits before it. The test must **fail** against the old
+   `find(existsSync)` `pick` and **pass** with the fix.
+4. Follow house style (no `as`/`any`/`ts-ignore`; Prettier printWidth 50).
+
+## Quality Gate
+
+**Objective pass condition:**
+
+1. **Fix present:** `packages/plgg-bundle/bin/hook.mjs` `pick` matches files only
+   (`statSync(c).isFile()`); a bare-directory `plgg-bundle/<dir>` specifier
+   resolves to `<dir>/index.ts`.
+2. **Copies in sync:** the `pick`/`isFile` region of
+   `packages/plgg-bundle/bin/hook.mjs` and `packages/plggpress/bin/hook.mjs` is
+   identical (verify with `diff`).
+3. **Regression test (live trigger):** a plgg-bundle spec calls `resolve()` with
+   a bare-directory self-alias and asserts the returned `url` ends in
+   `/index.ts` (and is a file URL), not the bare directory. Demonstrate it
+   **red on the old `pick`** (temporarily revert to `find(existsSync)` → test
+   fails) and **green with the fix**.
+4. **Suite green:** `scripts/tsc-plgg.sh` clean where applicable and
+   `./scripts/test-plgg-bundle.sh` passes; a fresh `scripts/check-all.sh` is
+   green (plgg-bundle coverage stays >90% across statements/branches/functions/lines).
+
+**Edge cases to cover in the test:** a directory *with* `index.ts` (resolves to
+index.ts); a specifier that maps to a real `.ts` file (still resolves to the
+file — the fix must not regress the common case); a specifier with no matching
+file or index (falls through to `nextResolve`).
+
+## Considerations
+
+- Pure bug fix + guard; no behavior change for the existing file-specifier path.
+- Keep the two hook copies verbatim-synced; if this recurs, consider extracting
+  a single shared hook module instead of copies (out of scope here — record as a
+  follow-up if the duplication keeps drifting).

--- a/packages/plgg-bundle/bin/hook.d.mts
+++ b/packages/plgg-bundle/bin/hook.d.mts
@@ -1,0 +1,20 @@
+// Hand-written types for the JS loader hook (the hook must
+// stay a plain `.mjs` — it runs as Node's ESM resolver
+// before any type-stripping is active — so it carries no
+// inferable types). Declared here so a `.ts` spec can drive
+// `resolve` type-safely under `allowJs: false`.
+
+/** A resolved module, as returned to Node's loader chain. */
+export type Resolved = {
+  url: string;
+  shortCircuit?: boolean;
+};
+
+export const resolve: (
+  specifier: string,
+  context: { parentURL?: string | undefined },
+  nextResolve: (
+    specifier: string,
+    context: { parentURL?: string | undefined },
+  ) => Promise<Resolved>,
+) => Promise<Resolved>;

--- a/packages/plgg-bundle/bin/hook.mjs
+++ b/packages/plgg-bundle/bin/hook.mjs
@@ -19,7 +19,7 @@
 //
 // Everything else (typescript, node:*) falls through to
 // Node's default resolution.
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -27,13 +27,22 @@ const here = dirname(fileURLToPath(import.meta.url));
 const srcRoot = join(here, "..", "src");
 const prefix = "plgg-bundle/";
 
+// Resolve to a FILE, never a directory: a bare-directory
+// self-alias (e.g. `plgg-bundle/foo`) must land on its
+// `index.ts`, not the directory itself — Node would `read`
+// the directory and throw EISDIR. So the raw `base` matches
+// only when it is a real file; a directory falls through to
+// `base/index.ts`.
+const isFile = (c) =>
+  existsSync(c) && statSync(c).isFile();
+
 const pick = (base) => {
   const candidates = [
     base,
     `${base}.ts`,
     join(base, "index.ts"),
   ];
-  return candidates.find((c) => existsSync(c));
+  return candidates.find(isFile);
 };
 
 // The `?v=<n>` dev version carried by an importer URL, or

--- a/packages/plgg-bundle/src/Dev/fixtures/aliasDir/index.ts
+++ b/packages/plgg-bundle/src/Dev/fixtures/aliasDir/index.ts
@@ -1,0 +1,6 @@
+// Fixture: a directory whose only module is `index.ts`, so a
+// bare-directory self-alias (`plgg-bundle/Dev/fixtures/aliasDir`)
+// has an index to resolve to. Exercised by
+// ../../usecase/selfAliasResolve.spec.ts to guard the loader
+// hook against resolving to the directory itself (EISDIR).
+export const marker = "aliasDir/index.ts";

--- a/packages/plgg-bundle/src/Dev/usecase/selfAliasResolve.spec.ts
+++ b/packages/plgg-bundle/src/Dev/usecase/selfAliasResolve.spec.ts
@@ -1,0 +1,68 @@
+import {
+  test,
+  check,
+  all,
+  toBe,
+} from "plgg-test";
+import {
+  resolve,
+  type Resolved,
+} from "../../../bin/hook.mjs";
+
+// The loader hook's `resolve` rewrites `plgg-bundle/<sub>`
+// self-alias specifiers to on-disk `src/<sub>` files. These
+// drive it directly (the alias branch short-circuits before
+// `nextResolve`, so a stub suffices).
+
+const ctx = { parentURL: undefined };
+const fallthrough = async (): Promise<Resolved> => ({
+  url: "file:///fallthrough",
+});
+
+test(
+  "bare-directory self-alias resolves to its index.ts, not the directory (EISDIR guard)",
+  async () => {
+    const r = await resolve(
+      "plgg-bundle/Dev/fixtures/aliasDir",
+      ctx,
+      fallthrough,
+    );
+    return all([
+      check(
+        r.url.endsWith("/aliasDir/index.ts"),
+        toBe(true),
+      ),
+      check(r.shortCircuit ?? false, toBe(true)),
+    ]);
+  },
+);
+
+test(
+  "file self-alias still resolves to the .ts file (no regression)",
+  async () => {
+    const r = await resolve(
+      "plgg-bundle/index",
+      ctx,
+      fallthrough,
+    );
+    return check(
+      r.url.endsWith("/src/index.ts"),
+      toBe(true),
+    );
+  },
+);
+
+test(
+  "a self-alias with no matching file falls through to nextResolve",
+  async () => {
+    const r = await resolve(
+      "plgg-bundle/does/not/exist",
+      ctx,
+      fallthrough,
+    );
+    return check(
+      r.url,
+      toBe("file:///fallthrough"),
+    );
+  },
+);


### PR DESCRIPTION

## 1. Overview

A one-ticket follow-up to PR #55: fix the latent twin of a bug that PR #55 already fixed in production. The plgg-bundle ESM loader hook (`bin/hook.mjs`) resolved a bare-directory self-alias to the directory itself — which Node then `read`s as a module and throws `EISDIR`. The fix makes resolution match files only (a directory falls through to its `index.ts`), re-syncs the two near-verbatim hook copies, and adds a typed regression test.

**Highlights:**

1. `plgg-bundle/bin/hook.mjs` `pick()` matches files only, so `plgg-bundle/<dir>` resolves to `<dir>/index.ts` instead of the directory (EISDIR guard).
2. The two near-verbatim hook copies (plgg-bundle + plggpress) are back in sync — plggpress's was fixed live in PR #55 (`4c3341b`); this closes the un-fixed original.
3. A typed regression spec proves it — red on the old `pick`, green on the fix — despite the hook being a plain `.mjs` under `allowJs:false`.

## 2. Motivation

PR #55 absorbed plggmatic into plggpress, which introduced the first bare-directory self-alias (`plggpress/framework`) and thereby surfaced this hook bug as an `EISDIR` crash of the guide's static deploy build. That was fixed in plggpress's copy of the hook. The plgg-bundle original — the copy every package builds through — carried the identical `pick()` and was left unfixed: latent only because no plgg-bundle consumer bare-imports a directory *yet*. Fixing it now removes a trap for the next such import and restores the "near-verbatim copy" invariant the two hook files are meant to hold. This is implementation-pillar hygiene: make a machine-checkable guard out of a failure that was previously invisible until runtime.

## 3. Changes

```mermaid
flowchart LR
  a1[PR #55: plggpress/framework bare-dir import] --> a2[EISDIR surfaced in plggpress hook]
  a2 --> a3[Fixed plggpress/bin/hook.mjs]
  a3 --> a4[plgg-bundle/bin/hook.mjs: same pick, unfixed]
  a4 --> b1[pick matches files only]
  b1 --> b2[re-sync the two hook copies]
  b2 --> b3[typed regression: hook.d.mts + fixture + spec]
  b3 --> b4[red-on-old / green-on-fix]
```

The `pick` helper gained an `isFile` guard (`existsSync(c) && statSync(c).isFile()`) so the raw `base` candidate matches only real files; a directory now resolves to `base/index.ts`. Because the hook must stay plain `.mjs` (it runs as Node's resolver before any type-stripping) and the package sets `allowJs:false` with `.spec.ts`-only discovery, the test needed a hand-written `bin/hook.d.mts` to type `resolve` without an escape hatch, a coverage-excluded `aliasDir/` fixture, and a spec driving `resolve()` directly.

## 4. Outcome

The ticket is implemented, verified, and archived; the todo queue is empty.

- Regression proven **red-on-old** (buggy `pick` → the directory test fails) and **green-on-fix**.
- The two hook copies' `pick`/`isFile` bodies are now **identical**.
- plgg-bundle: **83 tests pass**, coverage **99.8 / 94.3 / 98.8 / 99.8%** (all >90%).
- Fresh **`check-all.sh` green** across every package (plgg-bundle, plgg, plggpress, plgg-auth 217, …).

## 5. Historical Analysis

Directly continuous with PR #55 (`work-20260703-184443`), which introduced the first bare-directory self-alias and fixed the plggpress copy of the hook (`4c3341b`). The hook itself dates to the plgg-bundle dev-server/self-alias work; the "near-verbatim copy" split into plggpress's bin was made when plggpress gained its own CLI. This ticket reunifies the two after their PR-#55 divergence.

## 6. Concerns

- **No new deferred concerns.** Pure bug fix plus a regression guard; the common file-resolution path is unchanged and explicitly covered by a no-regression test.
- Standing note (not introduced here): the two hook files remain hand-maintained copies. If they drift again, extracting a single shared module is the durable fix — out of scope for this bugfix, worth a ticket only if the duplication recurs.

## 7. Successful Development Patterns

- **Chase the twin.** A production fix in one copy immediately motivated auditing its near-verbatim sibling, closing a latent crash before it could surface.
- **Make the invisible machine-checkable.** The bug was a runtime `EISDIR` with no test; the fix ships with a red/green regression that would have caught it, and re-establishes the copies-in-sync invariant as a verifiable condition.
- **Type the seam honestly.** Rather than reach for an escape hatch to test an untyped `.mjs` loader under `allowJs:false`, a hand-written `.d.mts` kept the test strict and `any`-free.
