### PR TITLE
Close plggmatic-ai-native-ui mission as achieved (HQ triage)

### DIFF
--- a/.workaholic/missions/archive/plggmatic-ai-native-ui-toward-a-dsl/mission.md
+++ b/.workaholic/missions/archive/plggmatic-ai-native-ui-toward-a-dsl/mission.md
@@ -2,7 +2,7 @@
 type: Mission
 title: plggmatic AI-native UI toward a DSL
 slug: plggmatic-ai-native-ui-toward-a-dsl
-status: active
+status: achieved
 created_at: 2026-07-08T21:45:15+09:00
 author: a@qmu.jp
 tickets: [20260708213945-specify-pragmatic-screen-transition-model.md, 20260708213946-specify-pragmatic-input-field-model.md]
@@ -35,8 +35,8 @@ The mission's outcome is a **DSL**: an AI writes code in that language and the r
 - [x] The Pragmatic concept is recorded as the project's north-star, done at mission creation (#20260708-pragmatic-ai-native-ui-concept.md)
 - [x] The probabilistic screen-transition model is specified with concrete AI-generatable + AI-operable properties, grounded in the samples (#20260708213945-specify-pragmatic-screen-transition-model.md)
 - [x] The input-field model is specified with concrete AI-generatable + AI-operable properties, grounded in the samples (#20260708213946-specify-pragmatic-input-field-model.md)
-- [ ] The DSL is distilled from the specifications and produces a working on-demand UI from a declarative description (delivered by the `plggmatic-screen-structure-model-semantics` mission, migrated 2026-07-11 to the `qmu/plggmatic` repo; checked off here when that mission's DSL v1 lands)
-- [ ] A generated UI is demonstrated to be WebMCP/MCP-Apps operable by a browser-side agent (delivered by the `plggmatic-screen-structure-model-semantics` mission in `qmu/plggmatic`; checked off here when its WebMCP adapter + prototype land)
+- [x] The DSL is distilled from the specifications and produces a working on-demand UI from a declarative description (delivered by the `plggmatic-screen-structure-model-semantics` mission, migrated 2026-07-11 to the `qmu/plggmatic` repo; checked off here when that mission's DSL v1 lands)
+- [x] A generated UI is demonstrated to be WebMCP/MCP-Apps operable by a browser-side agent (delivered by the `plggmatic-screen-structure-model-semantics` mission in `qmu/plggmatic`; checked off here when its WebMCP adapter + prototype land)
 
 ## Changelog
 
@@ -60,3 +60,5 @@ The mission's outcome is a **DSL**: an AI writes code in that language and the r
 - 2026-07-16 — concern deferred (stuck) — new-exports-are-not-yet-on.md
 - 2026-07-16 — ticket archived — 20260716161118-publish-dialect-packages.md
 - 2026-07-16 — story reported — work-20260716-161106.md
+- 2026-07-16 — remaining two acceptance items verified against qmu/plggmatic and ticked: DSL v1 core spec frozen 2026-07-13 (dsl-v1-core.md, plggmatic commit 5a9a5d7, Flow static layer 681fa71) and WebMCP adapter + runnable prototype landed 2026-07-14 (plggmatic commit 93835e1 "Add the Tool catalog and WebMCP adapter", pausable-interpreter handshake prototype ticket 20260712141400) — HQ triage (strategy mission qfs-viewer-mvp-headquarters)
+- 2026-07-16 — mission achieved — mission.md

--- a/.workaholic/missions/index.md
+++ b/.workaholic/missions/index.md
@@ -3,9 +3,9 @@
 ## active
 
 * [modernize-plgg-bundle](active/modernize-plgg-bundle/mission.md) - Modernize plgg-bundle
-* [plggmatic-ai-native-ui-toward-a-dsl](active/plggmatic-ai-native-ui-toward-a-dsl/mission.md) - plggmatic AI-native UI toward a DSL
 * [plggpress-technical-confidence-poc-portal](active/plggpress-technical-confidence-poc-portal/mission.md) - plggpress technical-confidence PoC portal
 
 ## archive
 
 * [build-the-plgg-ir-package-family](archive/build-the-plgg-ir-package-family/mission.md) - Build the plgg-ir Package Family
+* [plggmatic-ai-native-ui-toward-a-dsl](archive/plggmatic-ai-native-ui-toward-a-dsl/mission.md) - plggmatic AI-native UI toward a DSL

--- a/.workaholic/release-notes/index.md
+++ b/.workaholic/release-notes/index.md
@@ -33,4 +33,5 @@
 * [plgg-md accepts the frontmatter we actually write, opens the heading seam, and fixes three grammar bugs](work-20260716-014150.md)
 * [Conclude PoC 5 (central configuration generation) proven, etc](work-20260716-023712.md)
 * [Export the domain vocabulary as a composable manifestDialect, etc](work-20260716-115204.md)
+* [Bump plgg-ir-language and plgg-ir-manifest to 0.0.2 for the dialect-export publish](work-20260716-161106.md)
 * [Re-extract plgg-mcp as the content-free MCP protocol substrate, etc](work-20260716-163314.md)


### PR DESCRIPTION
## Summary

Closes the `plggmatic-ai-native-ui-toward-a-dsl` mission (was 3/5) as **achieved**, after verifying and ticking its two remaining acceptance items. Filed under HQ triage, strategy ticket **20260716212001** (strategy mission `qfs-viewer-mvp-headquarters`).

## Verification evidence (qmu/plggmatic)

- **"The DSL is distilled … checked off here when that mission's DSL v1 lands"** — satisfied: `dsl-v1-core.md` is marked **FROZEN 2026-07-13** (plggmatic commit `5a9a5d7`, "Freeze the DSL v1 core on the plgg-ir family"), with the Flow static layer implemented in `681fa71`. The delegated `plggmatic-screen-structure-model-semantics` mission's "DSL v1 core specification frozen" acceptance item is ticked.
- **"A generated UI is demonstrated to be WebMCP/MCP-Apps operable … checked off here when its WebMCP adapter + prototype land"** — satisfied: plggmatic commit `93835e1` (2026-07-14, "Add the Tool catalog and WebMCP adapter", `packages/plggmatic/src/Catalog/*` with adapter + tests), and the "Pausable-interpreter ↔ settle-loop handshake proven by a runnable prototype" acceptance item (ticket `20260712141400`) is ticked in the same mission.

## Changes

- Ticked the two acceptance items and appended an evidence changelog line (append-only).
- Ran mission `close.sh` → `{"closed": true, "status": "achieved"}`; mission archived to `.workaholic/missions/archive/plggmatic-ai-native-ui-toward-a-dsl/mission.md`, missions index regenerated (release-notes index picked up a previously unindexed entry as a side effect of the regeneration).

Do not merge without human review — opened for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)