### PR TITLE
Add tickets for PoC removal and lockfile hygiene

### DIFF
--- a/.workaholic/tickets/todo/a-qmu-jp/20260806211627-remove-the-poc-fleet-packages.md
+++ b/.workaholic/tickets/todo/a-qmu-jp/20260806211627-remove-the-poc-fleet-packages.md
@@ -1,0 +1,162 @@
+---
+created_at: 2026-08-06T21:16:27+09:00
+author: a@qmu.jp
+type: housekeeping
+layer: [Infrastructure]
+effort:
+commit_hash:
+category:
+depends_on:
+mission:
+merge_policy: auto
+---
+
+# PoC フリートの 9 パッケージを撤去する
+
+## Overview
+
+`packages/plgg-poc*` の 9 パッケージ（`plgg-poc-portal` / `plgg-poc1-search` /
+`plgg-poc2-agent` / `plgg-poc3-voice` / `plgg-poc4-edit` / `plgg-poc4b-coedit` /
+`plgg-poc4c-livesite` / `plgg-poc5-config` / `plgg-poc6-classify`、計 142 の
+`.ts` ファイル）を、その配線ごとリポジトリから撤去する。**開発者の判断
+（2026-08-06）**であり、技術的な不具合の修正ではない。
+
+これらは「確信を集める PoC フリート」として作られたもので、いずれも
+`private: true`、npm 未公開、`plgg-poc*.qmu.dev` で配信されていた。2026-07-19 の
+qfs ピボットで PoC フリート（コンテナ群）自体は既に消えており、残っているのは
+ソースと配線だけである。
+
+### 副次的に片付くもの
+
+dependabot の open アラート 2 件（`sharp` < 0.35.0、libvips 由来の CVE-2026-33327
+/ 33328 / 35590 / 35591、いずれも high）は**このチケットで消える**。`sharp` は
+直接依存ではなく、`plgg-poc1-search` の devDependency である
+`@huggingface/transformers` ^3.5.1 が引く推移依存だからである。
+
+これは重要な副次効果であって、このチケットの動機ではない。動機は「PoC はもう
+要らない」という判断で、脆弱性はその結果として消える。**逆にこの副次効果を
+当てにして削除範囲を狭めないこと** — 例えば poc1-search だけ残すと `sharp` も
+残る。
+
+なお `overrides` で `sharp` を 0.35 以上にピン留めする道は検討したが採らない。
+最新の `@huggingface/transformers@4.2.0` でも `sharp: ^0.34.5` を宣言しており
+（キャレットは 0.x でマイナーを固定するので 0.35.x を含まない）、親の宣言を
+越えたピン留めになるため、transformers 側の壊れ方が保証されないからである。
+パッケージごと消えるなら、その判断自体が不要になる。
+
+## Policies
+
+- `workaholic:design` / `policies/sacrificial-architecture.md` — 「捨てて作り直す
+  ことが通常の選択肢である」ように境界を引く。PoC はまさにその犠牲的単位であり、
+  役目を終えたら消せることが設計の成立条件だった。今回はその回収。
+- `workaholic:design` / `policies/vendor-neutrality.md` — `@huggingface/transformers`
+  は PoC の node 側埋め込みでしか使われていない重い外部依存（browser 側は
+  jsdelivr の CDN URL を直接読む）。撤去は依存の自由度を回復する方向。
+- `workaholic:implementation` / `policies/directory-structure.md` — パッケージを
+  消すときは、その配線（テストランナー、README 索引、workloads、CI）も同時に
+  消す。片方だけ残ると「構造から場所が予測できる」性質が壊れる。
+- `workaholic:implementation` / `policies/objective-documentation.md` — README の
+  記述は実在するものを指していなければならない。9 行の索引エントリを残したまま
+  パッケージを消すと、`gate-readme.sh` が落ちる（それが正しい）。
+- `workaholic:operation` / `policies/ci-cd.md` — 緑になったことではなく、
+  実際に何が検査されたかが証拠。ここでは「消し残りが無いこと」を grep で
+  積極的に示す。
+
+## Key Files
+
+- `packages/plgg-poc-portal/`, `packages/plgg-poc1-search/`,
+  `packages/plgg-poc2-agent/`, `packages/plgg-poc3-voice/`,
+  `packages/plgg-poc4-edit/`, `packages/plgg-poc4b-coedit/`,
+  `packages/plgg-poc4c-livesite/`, `packages/plgg-poc5-config/`,
+  `packages/plgg-poc6-classify/` — 削除対象本体。
+- `scripts/test-plgg-poc-portal.sh` ほか計 9 本の `test-plgg-poc*.sh` — 各
+  パッケージ専用のテストランナー。パッケージと同時に消す。
+- `scripts/serve-poc.sh` — PoC フリートの配信スクリプト。対象が全部消えるので
+  スクリプトごと不要。**ルート `.env` を source する唯一の利用者**かどうかを
+  確認してから消すこと（`.env` 規約に触れる）。
+- `workloads/poc-portal/`, `workloads/poc1-search/` … `workloads/poc6-classify/`
+  — 9 つの compose / Dockerfile / dev-entrypoint。同時に消す。
+- `README.md` 135〜143 行 — パッケージ索引の 9 エントリ。`gate-readme.sh` が
+  「実在する全パッケージが README にリンクされ、リンクが切れていないこと」を
+  強制するので、消し残すとゲートが落ちる。
+- `scripts/build.sh` — **29 パッケージを名前で列挙しており、PoC は 1 つも入って
+  いない**。check-all のゲート順にも入っていない。つまり PoC フリートは既に
+  「ゲートから外された」状態で、残っていたのはソースと配線だけ。この事実が
+  この撤去のリスクを小さくしている（消してもゲートの構成は変わらない）。
+  ただし `packages/*` の workspaces glob には入っているので、**ルートの
+  lockfile には devDependency が流れ込んでいる** — それが `sharp` の経路。
+- `~/.cloudflared/config.yml` — `plgg-poc*.qmu.dev` の ingress ルート。
+  **これはリポジトリ外**（サーバの設定）なので、このチケットでは触らず、
+  撤去が必要なら別途手当てする旨を Final Report に書く。
+
+## Implementation Steps
+
+1. 9 パッケージのディレクトリを削除する。
+2. `scripts/test-plgg-poc*.sh` 9 本と `scripts/serve-poc.sh` を削除する
+   （`serve-poc.sh` が他から呼ばれていないことを grep で確認してから）。
+3. `workloads/poc*/` 9 ディレクトリを削除する。
+4. `README.md` のパッケージ索引から 9 エントリを削除する。周辺の見出しや導入文が
+   PoC フリートに言及していないか確認し、していれば整合させる。
+5. ルートの `package-lock.json` を再生成する（`./scripts/npm-install.sh`）。
+   `@huggingface/transformers` と `sharp` がロックから消えることを確認する。
+6. リポジトリ全体を grep して消し残りをゼロにする。`.workaholic/` 配下の
+   **アーカイブ済みチケット・ストーリー・フィードバック・リリースノート・
+   ミッションは履歴なので触らない**（過去の記録が過去を指しているのは正しい）。
+
+## Quality Gate
+
+**Acceptance criteria**
+
+- `ls -d packages/plgg-poc*` が何も返さない。
+- `ls scripts/test-plgg-poc*.sh scripts/serve-poc.sh` が何も返さない。
+- `ls -d workloads/poc*` が何も返さない。
+- `grep -n "plgg-poc" README.md` が何も返さない。
+- 履歴領域を除いた全体 grep が空:
+  `git grep -l "plgg-poc" -- . ':!.workaholic/tickets/archive' ':!.workaholic/stories' ':!.workaholic/feedbacks' ':!.workaholic/release-notes' ':!.workaholic/missions'`
+- `git grep -l "huggingface\|sharp" -- package-lock.json` が空、かつ
+  `npm ls sharp` が何も見つけない。
+- `./scripts/check-all.sh` が緑（exit 0）。特に `gate-readme.sh` が通ること
+  （README 索引とパッケージ実体の対応が壊れていないことの機械的証明）。
+- GitHub の dependabot アラートが 0 件になる:
+  `gh api repos/qmu/plgg/dependabot/alerts --jq '[.[]|select(.state=="open")]|length'`
+  が `0`。**マージ後に確認**すること（アラートは main の依存グラフで再評価される）。
+
+**Verification method**
+
+- 上記をそのままコマンドとして実行し、出力を Final Report に貼る。
+- `./scripts/check-all.sh` を最後に 1 回。
+
+**Gate**
+
+- check-all 緑、かつ上の消し残り grep がすべて空。dependabot アラートの 0 件は
+  マージ後の確認項目として報告に残す（マージ前には確定できない）。
+
+`Decided:` **`overrides` による `sharp` のピン留めは行わない。** パッケージごと
+消えるので不要であり、親が宣言していないバージョンを強制するリスクを負う理由が
+無くなる（`/drive` で開発者が上書き可）。
+
+`Decided:` **`.workaholic/` の履歴領域（archive / stories / feedbacks /
+release-notes / missions）は書き換えない。** 過去の記録が当時存在したものを
+指しているのは正しい状態で、遡って消すと履歴が嘘になる（`/drive` で開発者が
+上書き可）。
+
+`Decided:` **cloudflared の ingress（`plgg-poc*.qmu.dev`）はこのチケットでは
+触らない。** リポジトリ外のサーバ設定であり、コード変更の受入と混ぜると
+「緑なのに片付いていない」状態を作る。撤去が必要な事実だけ Final Report に
+書き残す（`/drive` で開発者が上書き可）。
+
+## Considerations
+
+- **削除は一括で。** 9 パッケージのうち一部だけ残すと、`sharp` が残る
+  （poc1-search）だけでなく、`plgg-poc-portal` が他の PoC を索引しているため
+  リンク切れが出る。分割するなら portal を最後に消すこと。
+- **`serve-poc.sh` とルート `.env`。** メモリ上、`serve-poc.sh` はルートの
+  git-ignored `.env` を source する数少ない利用者。消したあとに `.env` の
+  どのキーが誰にも読まれなくなるかを確認し、必要なら `.env.example` を整合させる。
+- **workloads の podman コンテナ。** 停止・削除されていないコンテナが残っている
+  場合、compose ファイルを消しても podman 側には残る。リポジトリの受入には
+  含めないが、Final Report で状態を報告すること。
+- **guide への影響は無い見込み。** `packages/guide/packages/` に poc のページは
+  存在しない（確認済み）。ただし guide の本文が PoC に言及していないかは
+  ビルドで dead-link 検査に掛かるので、`cd packages/guide && npm run build` も
+  一度通しておくとよい。

--- a/.workaholic/tickets/todo/a-qmu-jp/20260806211627-remove-the-poc-fleet-packages.md
+++ b/.workaholic/tickets/todo/a-qmu-jp/20260806211627-remove-the-poc-fleet-packages.md
@@ -147,9 +147,12 @@ release-notes / missions）は書き換えない。** 過去の記録が当時�
 
 ## Considerations
 
-- **削除は一括で。** 9 パッケージのうち一部だけ残すと、`sharp` が残る
-  （poc1-search）だけでなく、`plgg-poc-portal` が他の PoC を索引しているため
-  リンク切れが出る。分割するなら portal を最後に消すこと。
+- **削除は一括で。これは好みではなく構造上の要請。** `plgg-poc2-agent` /
+  `plgg-poc3-voice` / `plgg-poc4-edit` / `plgg-poc4b-coedit` /
+  `plgg-poc4c-livesite` の 5 本が `plgg-poc1-search` に **`file:` 依存**して
+  いる。poc1-search だけ残す/消すといった部分削除は依存を壊すか `sharp` を
+  残すかのどちらかになる。加えて `plgg-poc-portal` は他の PoC を索引している
+  のでリンク切れも出る。分割するなら portal を最後に消すこと。
 - **`serve-poc.sh` とルート `.env`。** メモリ上、`serve-poc.sh` はルートの
   git-ignored `.env` を source する数少ない利用者。消したあとに `.env` の
   どのキーが誰にも読まれなくなるかを確認し、必要なら `.env.example` を整合させる。

--- a/.workaholic/tickets/todo/a-qmu-jp/20260806211628-untrack-stale-lockfiles-and-fix-dependabot-config.md
+++ b/.workaholic/tickets/todo/a-qmu-jp/20260806211628-untrack-stale-lockfiles-and-fix-dependabot-config.md
@@ -96,6 +96,16 @@ lockfile の撤去は一度も出てこない — 片付け対象として書か
 3. `.github/dependabot.yml` の `directories` を `["/"]` に変更し、偽になった
    コメントを現状に合わせて書き直す（workspaces のルートが唯一の install root）。
 4. `docs/npm-workspaces-decision.md` の lockfile 行を事実に合わせる。
+5. workspaces 移行で偽になった他の記述も同じ PR で直す（`objective-documentation`
+   — 実際の挙動を書く）:
+   - ルート `package.json` の `description` が今も
+     `"SPIKE: npm workspaces evaluation for ticket 20260721180002."` のまま。
+     spike は 2026-08-01 に採用として決着しているので、現状を書く。
+   - `scripts/gate-guide-deps.sh` 40 行目と `workloads/guide/dev-entrypoint.sh`
+     76 行目のコメントが `build.sh` の `npm ci` bootstrap に言及しているが、
+     `build.sh` は現在 `node_modules/typescript` が無いときだけ**ルートの
+     `npm install`** を走らせる。`npm ci` は**リポジトリのどこにも実行として
+     存在しない**。
 5. ルートで `./scripts/npm-install.sh` を実行し、ルートの lockfile 以外が
    生成・変更されないことを確認する。
 
@@ -144,12 +154,23 @@ install root が全 workspace の依存を解決するので、パッケージ�
   (`20260806211627`) に `depends_on` している。PoC を先に消せば 39 本のうち
   9 本が一緒に消えるので、こちらの対象は 30 本になる。逆順でも壊れないが、
   受入の数え方が変わるので順序を守るほうが読みやすい。
-- **`npm ci` を使っている箇所は無い。** `scripts/` と `.github/` を grep した
-  範囲では `npm ci` はコメント内の言及のみで、実際の呼び出しは
-  `scripts/build.sh` の `npm install` と `scripts/npm-install.sh` のルート
-  install だけ。したがって per-package lockfile を消しても再現性のある install
-  は壊れない。**この前提はドライブ時に再確認すること**（新しい呼び出しが
-  増えていれば話が変わる）。
+- **`npm ci` を使っている箇所は無い（確認済み）。** リポジトリ全体で `npm ci` は
+  **実行として 1 箇所も存在しない** — ヒットするのは上記 2 つの陳腐化した
+  コメントとアーカイブ済み文書だけ。install 経路は `scripts/npm-install.sh` の
+  ルート `npm install`、`build.sh` の条件付きルート install、ガイドコンテナの
+  per-package `npm install` ループ（`ci` ではない）の 3 つ。**どのワークフローも
+  lockfile をキーにしたキャッシュを使っていない**（`actions/setup-node` の
+  cache 未使用）ので、消しても再現性のある install も CI キャッシュも壊れない。
+  それでもドライブ時に再確認すること（新しい呼び出しが増えていれば話が変わる）。
+- **アラートと更新 PR は別経路。** GitHub の依存グラフはリポジトリ内の**全**
+  lockfile を読むのでアラートは 2 件出る一方、`dependabot.yml` の `directories`
+  が支配するのは**更新 PR** だけ。したがって 39 本の追跡を外せばアラートは 1 件に
+  減り、設定をルートに向け直せば更新 PR が初めて生きた lockfile を対象にする。
+  **両方必要で、どちらか片方では閉じない。**
+- **凍った lockfile の腐り具合。** 39 本のうち 4 本
+  （poc2-agent / poc3-voice / poc4-edit / poc4b-coedit）は、自分の
+  `package.json` が宣言していない `@huggingface/transformers` のスタンザを
+  抱えている。生きた依存グラフの記録ではなく、単なる残骸である証拠。
 - **実体ファイルは消してもよいが必須ではない。** 追跡さえ外れれば、次の
   install が触らない限り無害。ただしコンテナ越しの npm が書き換える churn を
   完全に止めたいなら、実体も消しておくほうが静かになる。

--- a/.workaholic/tickets/todo/a-qmu-jp/20260806211628-untrack-stale-lockfiles-and-fix-dependabot-config.md
+++ b/.workaholic/tickets/todo/a-qmu-jp/20260806211628-untrack-stale-lockfiles-and-fix-dependabot-config.md
@@ -1,0 +1,155 @@
+---
+created_at: 2026-08-06T21:16:28+09:00
+author: a@qmu.jp
+type: housekeeping
+layer: [Config]
+effort:
+commit_hash:
+category:
+depends_on: [20260806211627-remove-the-poc-fleet-packages.md]
+mission:
+merge_policy: auto
+---
+
+# workspaces 移行が取り残した 39 個の lockfile と、それを前提にした dependabot 設定
+
+## Overview
+
+npm workspaces 移行（チケット `20260721180002`、コミット `cafb9107`、2026-08-01）は
+「1 回のルート install」への切り替えを完了させたが、**`packages/*/package-lock.json`
+39 本を追跡したまま残した**。移行チケットの受入にも実装手順にも Final Report にも
+lockfile の撤去は一度も出てこない — 片付け対象として書かれていたのは
+`node_modules` だけである。つまりこれは意図的な保持ではなく取りこぼしである。
+
+にもかかわらず `docs/npm-workspaces-decision.md` は測定表に
+`| Lockfiles | 39 | 1 |` という無条件の行を載せている。作業ツリーはこれを否定する。
+
+残った 39 本は 2026-07-13（`Sync package lockfiles to plgg-bundle 0.0.6`）で
+更新が止まっており、ルートの `package-lock.json` は 2026-08-01 に書き直されている。
+**片方は生き、39 本は凍っている。**
+
+### これが実際に起こしている害
+
+1. **同一の脆弱性がアラート 2 件に重複する。** dependabot は凍った
+   `packages/plgg-poc1-search/package-lock.json` とルートの lockfile の両方を
+   依存グラフとして読むので、`sharp` の CVE が 2 回数えられる。
+2. **`.github/dependabot.yml` が嘘の前提の上に立っている。** 設定は
+   `directories: ["/packages/*"]` だけを対象にし、インラインコメントは
+   *"No root package.json/workspaces: each packages/* dir is its own install root
+   (own package.json + package-lock.json)"* と書いている。この前提は `cafb9107`
+   で偽になった。結果、**version update は凍った 39 本に対して提案され、唯一
+   生きているルートの lockfile には一度も向かわない**。
+3. **コンテナが lockfile を書き換える。** 既存のフィードバック
+   `20260713203507-container-npm-rewrites-a-sibling-package.md` が記録している
+   とおり、`node:22-slim` の npm がバインドマウント越しに
+   `packages/plgg-poc1-search/package-lock.json` を libc フィールドの差分で
+   書き換え、これは 2 回 revert されて「また起きる」と書かれている。実際、この
+   セッション中にガイドコンテナを起動して同じ churn が再発した。**追跡を外せば
+   この concern も閉じる。**
+
+`20260803220507`（生成物 `tsconfig.dts.json` の untrack）とまったく同じ形の問題
+である — 生成物がソースツリーの一部として追跡され、ビルドのたびに worktree を
+汚す。
+
+## Policies
+
+- `workaholic:implementation` / `policies/directory-structure.md` — 生成物は
+  ソースツリーの一部として追跡しない。lockfile は install が生成するものであり、
+  workspaces 構成では**ルートの 1 本だけ**が生成される。
+- `workaholic:implementation` / `policies/objective-documentation.md` — ドキュメントは
+  実際の挙動を書く。`docs/npm-workspaces-decision.md` の `Lockfiles 39 → 1` は
+  現状を否定されている記述で、直すか脚注を付ける必要がある。
+- `workaholic:implementation` / `policies/infrastructure-as-code.md` — CI/bot の
+  設定はバージョン管理された事実であるべきで、実態と食い違ったまま放置しない。
+- `workaholic:operation` / `policies/ci-cd.md` — 「緑になった」ではなく「何を
+  検査したか」。dependabot が**何も見ていない**状態は緑と区別がつかないので、
+  設定変更後に実際にスキャン対象が正しいことを示す必要がある。
+- `workaholic:safety` — 脆弱性の検知経路が実質的に無効化されている状態は、
+  検知の不在であって安全の証明ではない。
+- `.workaholic/constraints/project.md` の Dependency Currency SLA — 「CVE を持つ
+  パッケージの dependabot PR を 30 日以上 open にしない」。**その SLA は、
+  dependabot が正しい lockfile を見ていて初めて意味を持つ。**
+
+## Key Files
+
+- `packages/*/package-lock.json` — 39 本。追跡を外す対象。
+- `.gitignore` — 生成物セクションがあり、直近で `**/tsconfig.dts.json` を
+  足したばかり。`packages/*/package-lock.json` の無視パターンをここに足す。
+  **ルートの `package-lock.json` は追跡し続けること**（唯一の真実）。
+  したがって `**/package-lock.json` のような書き方は禁物で、
+  `packages/*/package-lock.json` と限定して書く。
+- `.github/dependabot.yml` — `directories` をルート（`/`）に向け直し、
+  偽になったコメントを書き換える。npm workspaces ではルートの 1 install root が
+  全 workspace の依存を含むので、ルートだけで足りる。
+- `docs/npm-workspaces-decision.md` — `| Lockfiles | 39 | 1 |` の行。移行時点で
+  「install が生成する数」は確かに 1 になったが、追跡されている数は 39 のまま
+  だった、という事実に合わせる。
+- `scripts/npm-install.sh` — ルート 1 回 install であることの根拠。変更不要。
+- `.workaholic/feedbacks/20260713203507-container-npm-rewrites-a-sibling-package.md`
+  — このチケットで解消される既存 concern。Final Report で参照すること。
+
+## Implementation Steps
+
+1. `git rm --cached packages/*/package-lock.json` で 39 本の追跡を外す。
+2. `.gitignore` の生成物セクションに `packages/*/package-lock.json` を追加し、
+   なぜ 1 本だけ（ルート）が真実なのかを既存コメントの調子で 1〜2 行添える。
+3. `.github/dependabot.yml` の `directories` を `["/"]` に変更し、偽になった
+   コメントを現状に合わせて書き直す（workspaces のルートが唯一の install root）。
+4. `docs/npm-workspaces-decision.md` の lockfile 行を事実に合わせる。
+5. ルートで `./scripts/npm-install.sh` を実行し、ルートの lockfile 以外が
+   生成・変更されないことを確認する。
+
+## Quality Gate
+
+**Acceptance criteria**
+
+- `git ls-files | grep -c "packages/.*/package-lock.json"` が **0**。
+- `git ls-files package-lock.json` が**ルートの 1 本を返す**（消しすぎていない
+  ことの証明）。
+- `git check-ignore -v packages/plgg/package-lock.json` が exit 0、かつ
+  `git check-ignore -v package-lock.json` が**非ゼロ**（ルートは無視されない）。
+- `./scripts/npm-install.sh` の**直後に** `git status --porcelain` が**空**。
+- `.github/dependabot.yml` が `/` を対象にしており、`packages/*` を単独で
+  指していないこと。`yq`/`python3` で読んで確認する。
+- `./scripts/check-all.sh` が緑（exit 0）。
+
+**Verification method**
+
+- 上記をそのままコマンドとして実行し、出力を Final Report に貼る。
+- **マージ後の確認項目**として、dependabot の次回スキャンがルートの lockfile を
+  対象にしていること（Insights → Dependency graph、または新しい PR の対象パスが
+  `/package-lock.json` になっていること）を報告に残す。マージ前には確定できない。
+
+**Gate**
+
+- check-all 緑、かつ上の 6 点。
+
+`Decided:` **無視パターンは `packages/*/package-lock.json` と限定して書く。**
+`**/package-lock.json` にするとルートの唯一の真実まで無視され、`npm ci` 相当の
+再現性が失われる（`/drive` で開発者が上書き可）。
+
+`Decided:` **dependabot の対象はルート 1 本にする。** npm workspaces ではルートの
+install root が全 workspace の依存を解決するので、パッケージごとに向ける理由が
+無くなった。これが `directories: ["/packages/*"]` が書かれた当時の前提そのもの
+だった（`/drive` で開発者が上書き可）。
+
+`Decided:` **`docs/npm-workspaces-decision.md` は書き換えるが、測定値は改竄
+しない。** 当時の測定（install が生成する lockfile は 1 本）は正しく、誤りは
+「追跡されている 39 本を消していない」ことが書かれていない点なので、脚注として
+足す（`/drive` で開発者が上書き可）。
+
+## Considerations
+
+- **依存関係の順序。** このチケットは PoC 撤去チケット
+  (`20260806211627`) に `depends_on` している。PoC を先に消せば 39 本のうち
+  9 本が一緒に消えるので、こちらの対象は 30 本になる。逆順でも壊れないが、
+  受入の数え方が変わるので順序を守るほうが読みやすい。
+- **`npm ci` を使っている箇所は無い。** `scripts/` と `.github/` を grep した
+  範囲では `npm ci` はコメント内の言及のみで、実際の呼び出しは
+  `scripts/build.sh` の `npm install` と `scripts/npm-install.sh` のルート
+  install だけ。したがって per-package lockfile を消しても再現性のある install
+  は壊れない。**この前提はドライブ時に再確認すること**（新しい呼び出しが
+  増えていれば話が変わる）。
+- **実体ファイルは消してもよいが必須ではない。** 追跡さえ外れれば、次の
+  install が触らない限り無害。ただしコンテナ越しの npm が書き換える churn を
+  完全に止めたいなら、実体も消しておくほうが静かになる。


### PR DESCRIPTION
## Overview

Two open dependabot alerts traced to a transitive sharp CVE reachable only through the retired PoC fleet, and to 39 stale per-package lockfiles the npm-workspaces migration never untracked - which also point dependabot at frozen manifests instead of the one live lockfile

## Artifacts

- `.workaholic/tickets/todo/a-qmu-jp/20260806211627-remove-the-poc-fleet-packages.md`
- `.workaholic/tickets/todo/a-qmu-jp/20260806211628-untrack-stale-lockfiles-and-fix-dependabot-config.md`

## Notes

Published from the publish tree, so the caller's checkout was never touched. Merging this pull request is what lands the artifact on `main`.
